### PR TITLE
Add worktree dev infrastructure + LAN phone testing

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -95,12 +95,26 @@ app.use(globalRateLimit);
 app.use(securityHeaders);
 
 // Middleware
-const corsOrigins = env.CORS_ORIGINS
+const isProd = process.env.NODE_ENV === 'production';
+const explicitCorsOrigins = env.CORS_ORIGINS
   ? env.CORS_ORIGINS.split(',').map(s => s.trim())
   : ['http://localhost:5173', 'http://localhost:5174', 'http://localhost:3000', 'http://localhost:3002'];
+
+// In dev, also accept requests from any private-network origin (e.g. a phone
+// on the same Wi-Fi hitting the vite --host LAN URL).
+const privateNetworkOriginPattern = /^https?:\/\/(localhost|127\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)(:\d+)?$/;
+
 app.use(
   cors({
-    origin: corsOrigins,
+    origin(origin, callback) {
+      // Same-origin / curl / server-to-server requests have no Origin header.
+      if (!origin) return callback(null, true);
+      if (explicitCorsOrigins.includes(origin)) return callback(null, true);
+      if (!isProd && privateNetworkOriginPattern.test(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error(`CORS: origin ${origin} not allowed`));
+    },
     credentials: true,
   })
 );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -113,7 +113,12 @@ app.use(
       if (!isProd && privateNetworkOriginPattern.test(origin)) {
         return callback(null, true);
       }
-      return callback(new Error(`CORS: origin ${origin} not allowed`));
+      // Reject without throwing: returning `false` tells the cors middleware
+      // to omit CORS headers, so the browser blocks the request naturally.
+      // Throwing here would route through the global error handler and
+      // surface as a 500, polluting error logs for expected denials.
+      logger.warn({ origin }, 'CORS: origin not allowed');
+      return callback(null, false);
     },
     credentials: true,
   })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:lan": "node ./scripts/dev-lan.mjs",
     "prebuild": "node ./scripts/generate-robots.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/frontend/scripts/dev-lan.mjs
+++ b/frontend/scripts/dev-lan.mjs
@@ -102,8 +102,15 @@ console.log('  └────────────────────�
 console.log('');
 
 // Pass through any extra args after the script name (e.g. --port 5175).
+// If the user didn't specify --port, bind Vite to the FRONTEND_PORT we just
+// advertised in the phone URL — otherwise Vite falls back to its default
+// (5173) and the printed LAN URL is unreachable in worktrees with custom
+// ports.
 const extraArgs = process.argv.slice(2);
-const viteArgs = ['--host', '0.0.0.0', ...extraArgs];
+const hasPortArg = extraArgs.some((a) => a === '--port' || a.startsWith('--port='));
+const viteArgs = ['--host', '0.0.0.0'];
+if (!hasPortArg) viteArgs.push('--port', String(FRONTEND_PORT));
+viteArgs.push(...extraArgs);
 
 const child = spawn(
   'vite',

--- a/frontend/scripts/dev-lan.mjs
+++ b/frontend/scripts/dev-lan.mjs
@@ -1,0 +1,120 @@
+// Dev server for mobile testing on a real phone over LAN.
+//
+// What it does:
+// 1. Detects your Mac's LAN IP (en0 / en1 / first non-internal IPv4)
+// 2. Figures out the backend URL by reading .env.local if present, falling
+//    back to http://localhost:3002
+// 3. Rewrites the backend host to the LAN IP and passes it as VITE_API_URL
+// 4. Launches vite with --host so Vite binds to 0.0.0.0
+// 5. Prints the URL to open on your phone
+//
+// Works in both the main worktree (backend 3002, frontend 5174) and in
+// isolated worktrees that use different ports via .env.local / launch.json.
+// The backend CORS config already allows any LAN origin in dev mode.
+
+import { networkInterfaces } from 'node:os';
+import { spawn } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendDir = path.resolve(__dirname, '..');
+const envLocalPath = path.join(frontendDir, '.env.local');
+
+function parseEnvFile(filepath) {
+  if (!existsSync(filepath)) return {};
+  const out = {};
+  for (const line of readFileSync(filepath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+    out[key] = value;
+  }
+  return out;
+}
+
+const envLocal = parseEnvFile(envLocalPath);
+
+// Backend URL: prefer .env.local VITE_API_URL, then process env, then default.
+const rawApiUrl = envLocal.VITE_API_URL || process.env.VITE_API_URL || 'http://localhost:3002';
+
+// Frontend port: prefer VITE_SITE_URL in .env.local (has the port), then default.
+function extractPort(url, fallback) {
+  try {
+    const u = new URL(url);
+    return u.port || fallback;
+  } catch {
+    return fallback;
+  }
+}
+const FRONTEND_PORT = extractPort(envLocal.VITE_SITE_URL || '', '5174');
+
+function pickLanIp() {
+  const interfaces = networkInterfaces();
+  // Prefer en0 (built-in Wi-Fi on Macs), then en1, then any non-internal IPv4.
+  const priority = ['en0', 'en1'];
+  for (const name of priority) {
+    const addrs = interfaces[name] || [];
+    const match = addrs.find((a) => a.family === 'IPv4' && !a.internal);
+    if (match) return match.address;
+  }
+  for (const name of Object.keys(interfaces)) {
+    const addrs = interfaces[name] || [];
+    const match = addrs.find((a) => a.family === 'IPv4' && !a.internal);
+    if (match) return match.address;
+  }
+  return null;
+}
+
+const lanIp = pickLanIp();
+if (!lanIp) {
+  console.error('[dev:lan] Could not detect a LAN IP. Are you on Wi-Fi?');
+  process.exit(1);
+}
+
+const frontendUrl = `http://${lanIp}:${FRONTEND_PORT}/`;
+
+// Rewrite backend URL host to the LAN IP (keep port + scheme).
+let apiUrl;
+try {
+  const u = new URL(rawApiUrl);
+  u.hostname = lanIp;
+  apiUrl = u.toString().replace(/\/$/, '');
+} catch {
+  apiUrl = `http://${lanIp}:3002`;
+}
+
+console.log('');
+console.log('  ┌─────────────────────────────────────────────────┐');
+console.log('  │  LAN dev server — open on your phone:           │');
+console.log(`  │    ${frontendUrl.padEnd(45)}│`);
+console.log('  │                                                 │');
+console.log(`  │  API: ${apiUrl.padEnd(42)}│`);
+console.log('  │                                                 │');
+console.log('  │  Make sure the backend is also running:         │');
+console.log('  │    cd backend && npm run dev                    │');
+console.log('  └─────────────────────────────────────────────────┘');
+console.log('');
+
+// Pass through any extra args after the script name (e.g. --port 5175).
+const extraArgs = process.argv.slice(2);
+const viteArgs = ['--host', '0.0.0.0', ...extraArgs];
+
+const child = spawn(
+  'vite',
+  viteArgs,
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      VITE_API_URL: apiUrl,
+    },
+  },
+);
+
+child.on('exit', (code) => process.exit(code ?? 0));

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,8 +2,20 @@
  * Base HTTP client for API calls
  */
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3002';
 const isDev = import.meta.env.DEV;
+
+// In dev, derive the API base from the page's current hostname so the app
+// works when loaded from a LAN IP (e.g. on a phone at 192.168.1.62:5174 →
+// backend at 192.168.1.62:3002). In prod builds we honor VITE_API_URL.
+function resolveApiBaseUrl(): string {
+  if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
+  if (isDev && typeof window !== 'undefined' && window.location) {
+    return `${window.location.protocol}//${window.location.hostname}:3002`;
+  }
+  return 'http://localhost:3002';
+}
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 // Simple frontend logger
 const log = {

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# setup-worktree.sh — wire a fresh git worktree for dev: isolated ports,
+# matching env files, storage symlink, Claude Code launch.json, and deps.
+#
+# Run from inside the worktree you want to set up:
+#   ./scripts/setup-worktree.sh           # picks first free port offset
+#   ./scripts/setup-worktree.sh --offset 15   # force offset (frontend=5188, backend=3017)
+#
+# Idempotent: re-running in an already-set-up worktree updates launch.json
+# and re-creates the symlink but leaves your .env files alone unless --force.
+
+set -euo pipefail
+
+# ── locate worktree + main ──────────────────────────────────────────────────
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+MAIN_ROOT=$(git worktree list --porcelain | awk '/^worktree / { print $2; exit }')
+
+if [[ "$WORKTREE_ROOT" == "$MAIN_ROOT" ]]; then
+  echo "error: refusing to set up the main worktree ($MAIN_ROOT)."
+  echo "this script is only for secondary worktrees under .claude/worktrees/."
+  exit 1
+fi
+
+if [[ ! -f "$MAIN_ROOT/backend/.env" ]]; then
+  echo "error: main worktree is missing backend/.env — expected at $MAIN_ROOT/backend/.env"
+  echo "set up the main worktree first, then re-run this script."
+  exit 1
+fi
+
+# ── parse args ──────────────────────────────────────────────────────────────
+FORCE_ENV=false
+FORCED_OFFSET=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --offset) FORCED_OFFSET=$2; shift 2 ;;
+    --force)  FORCE_ENV=true; shift ;;
+    *) echo "unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# ── port selection ──────────────────────────────────────────────────────────
+# Main uses frontend 5174, backend 3002. Worktree N uses 5174+N, 3002+N.
+# We pick the smallest offset ≥ 10 whose port pair is free AND not already
+# claimed by another worktree's backend/.env.
+BASE_FRONTEND=5174
+BASE_BACKEND=3002
+
+port_in_use() {
+  lsof -i ":$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+offset_claimed_by_worktree() {
+  local offset=$1
+  local fe=$((BASE_FRONTEND + offset))
+  local be=$((BASE_BACKEND + offset))
+  for env_file in "$MAIN_ROOT"/.claude/worktrees/*/backend/.env; do
+    [[ -f "$env_file" ]] || continue
+    [[ "$env_file" == "$WORKTREE_ROOT/backend/.env" ]] && continue
+    if grep -qE "^PORT=$be$" "$env_file" 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# On re-runs we prefer whatever is already wired up, so launch.json / env
+# files don't drift. Ports are tracked independently (frontend/backend don't
+# have to be symmetric — a worktree set up by hand may have picked mixed
+# values). --force regenerates from a fresh offset.
+FRONTEND_PORT=""
+BACKEND_PORT=""
+
+if [[ -n "$FORCED_OFFSET" ]]; then
+  FRONTEND_PORT=$((BASE_FRONTEND + FORCED_OFFSET))
+  BACKEND_PORT=$((BASE_BACKEND + FORCED_OFFSET))
+elif [[ "$FORCE_ENV" != true ]]; then
+  if [[ -f "$WORKTREE_ROOT/backend/.env" ]]; then
+    EXISTING_BE=$(grep -E "^PORT=" "$WORKTREE_ROOT/backend/.env" | head -1 | cut -d= -f2 | tr -d '[:space:]')
+    [[ -n "$EXISTING_BE" ]] && BACKEND_PORT=$EXISTING_BE
+  fi
+  if [[ -f "$WORKTREE_ROOT/frontend/.env.local" ]]; then
+    EXISTING_FE=$(grep -E "^VITE_SITE_URL=" "$WORKTREE_ROOT/frontend/.env.local" | head -1 | sed -E 's|.*:([0-9]+).*|\1|')
+    [[ -n "$EXISTING_FE" ]] && FRONTEND_PORT=$EXISTING_FE
+  fi
+fi
+
+# Whatever's still empty: pick a fresh offset (symmetric from base).
+if [[ -z "$FRONTEND_PORT" || -z "$BACKEND_PORT" ]]; then
+  OFFSET=10
+  while true; do
+    FE=$((BASE_FRONTEND + OFFSET))
+    BE=$((BASE_BACKEND + OFFSET))
+    if ! port_in_use "$FE" && ! port_in_use "$BE" && ! offset_claimed_by_worktree "$OFFSET"; then
+      break
+    fi
+    OFFSET=$((OFFSET + 1))
+    if [[ $OFFSET -gt 99 ]]; then
+      echo "error: could not find a free port offset in range 10..99"
+      exit 1
+    fi
+  done
+  [[ -z "$FRONTEND_PORT" ]] && FRONTEND_PORT=$((BASE_FRONTEND + OFFSET))
+  [[ -z "$BACKEND_PORT" ]] && BACKEND_PORT=$((BASE_BACKEND + OFFSET))
+fi
+
+echo "worktree:     $WORKTREE_ROOT"
+echo "main:         $MAIN_ROOT"
+echo "frontend:     http://localhost:$FRONTEND_PORT"
+echo "backend:      http://localhost:$BACKEND_PORT"
+echo
+
+# ── backend/.env ────────────────────────────────────────────────────────────
+BE_ENV="$WORKTREE_ROOT/backend/.env"
+if [[ -f "$BE_ENV" && "$FORCE_ENV" != true ]]; then
+  echo "[skip] backend/.env already exists (use --force to overwrite)"
+else
+  cp "$MAIN_ROOT/backend/.env" "$BE_ENV"
+  # replace PORT= line
+  if grep -qE "^PORT=" "$BE_ENV"; then
+    sed -i.bak -E "s|^PORT=.*|PORT=$BACKEND_PORT|" "$BE_ENV" && rm "$BE_ENV.bak"
+  else
+    printf '\nPORT=%s\n' "$BACKEND_PORT" >> "$BE_ENV"
+  fi
+  # replace or append CORS_ORIGINS
+  if grep -qE "^CORS_ORIGINS=" "$BE_ENV"; then
+    sed -i.bak -E "s|^CORS_ORIGINS=.*|CORS_ORIGINS=http://localhost:$FRONTEND_PORT|" "$BE_ENV" && rm "$BE_ENV.bak"
+  else
+    printf 'CORS_ORIGINS=http://localhost:%s\n' "$FRONTEND_PORT" >> "$BE_ENV"
+  fi
+  echo "[write] backend/.env (PORT=$BACKEND_PORT, CORS_ORIGINS=http://localhost:$FRONTEND_PORT)"
+fi
+
+# ── frontend/.env.local ─────────────────────────────────────────────────────
+FE_ENV="$WORKTREE_ROOT/frontend/.env.local"
+if [[ -f "$FE_ENV" && "$FORCE_ENV" != true ]]; then
+  echo "[skip] frontend/.env.local already exists (use --force to overwrite)"
+else
+  cat > "$FE_ENV" <<EOF
+# worktree-local — generated by scripts/setup-worktree.sh
+VITE_API_URL=http://localhost:$BACKEND_PORT
+VITE_SITE_URL=http://localhost:$FRONTEND_PORT
+EOF
+  echo "[write] frontend/.env.local"
+fi
+
+# ── .claude/launch.json ─────────────────────────────────────────────────────
+LAUNCH="$WORKTREE_ROOT/.claude/launch.json"
+mkdir -p "$(dirname "$LAUNCH")"
+cat > "$LAUNCH" <<EOF
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port", "$FRONTEND_PORT", "--strictPort"],
+      "cwd": "frontend",
+      "port": $FRONTEND_PORT
+    },
+    {
+      "name": "backend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "cwd": "backend",
+      "port": $BACKEND_PORT
+    }
+  ]
+}
+EOF
+echo "[write] .claude/launch.json"
+
+# ── backend/storage symlink ─────────────────────────────────────────────────
+STORAGE_LINK="$WORKTREE_ROOT/backend/storage"
+STORAGE_TARGET="$MAIN_ROOT/backend/storage"
+if [[ ! -d "$STORAGE_TARGET" ]]; then
+  echo "[warn] main storage dir does not exist at $STORAGE_TARGET — skipping symlink"
+elif [[ -L "$STORAGE_LINK" ]]; then
+  if [[ "$(readlink "$STORAGE_LINK")" == "$STORAGE_TARGET" ]]; then
+    echo "[skip] backend/storage symlink already points at main"
+  else
+    rm "$STORAGE_LINK"
+    ln -s "$STORAGE_TARGET" "$STORAGE_LINK"
+    echo "[write] backend/storage -> $STORAGE_TARGET (replaced)"
+  fi
+elif [[ -e "$STORAGE_LINK" ]]; then
+  echo "[warn] backend/storage exists and is not a symlink — leaving alone"
+else
+  ln -s "$STORAGE_TARGET" "$STORAGE_LINK"
+  echo "[write] backend/storage -> $STORAGE_TARGET"
+fi
+
+# ── worktree-local exclude for the symlink ──────────────────────────────────
+# storage/ (trailing slash) in backend/.gitignore doesn't catch symlinks, so
+# add an explicit rule in the worktree's local exclude. Prevents `git add -A`
+# from staging a machine-specific absolute path.
+GIT_DIR=$(git rev-parse --git-dir)
+EXCLUDE_FILE="$GIT_DIR/info/exclude"
+mkdir -p "$(dirname "$EXCLUDE_FILE")"
+if ! grep -qE "^backend/storage$" "$EXCLUDE_FILE" 2>/dev/null; then
+  printf '\n# added by scripts/setup-worktree.sh — symlink is machine-specific\nbackend/storage\n' >> "$EXCLUDE_FILE"
+  echo "[write] .git/info/exclude (backend/storage)"
+fi
+
+# ── npm install ─────────────────────────────────────────────────────────────
+if [[ ! -d "$WORKTREE_ROOT/backend/node_modules" ]]; then
+  echo "[run]   backend npm install"
+  (cd "$WORKTREE_ROOT/backend" && npm install --silent)
+else
+  echo "[skip] backend/node_modules already present"
+fi
+
+if [[ ! -d "$WORKTREE_ROOT/frontend/node_modules" ]]; then
+  echo "[run]   frontend npm install"
+  (cd "$WORKTREE_ROOT/frontend" && npm install --silent)
+else
+  echo "[skip] frontend/node_modules already present"
+fi
+
+echo
+echo "done. in Claude Code, run:"
+echo "  preview_start backend"
+echo "  preview_start frontend"

--- a/scripts/stop-worktree-servers.sh
+++ b/scripts/stop-worktree-servers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# stop-worktree-servers.sh — kill whatever is listening on this worktree's
+# frontend/backend ports. Reads the ports from .claude/launch.json so it
+# only ever targets this worktree's own servers.
+#
+# Use when: Claude Code crashed and left dev servers orphaned, or you just
+# want a clean slate without touching the main worktree's servers.
+
+set -euo pipefail
+
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+LAUNCH="$WORKTREE_ROOT/.claude/launch.json"
+
+if [[ ! -f "$LAUNCH" ]]; then
+  echo "error: no .claude/launch.json in $WORKTREE_ROOT"
+  echo "run scripts/setup-worktree.sh first."
+  exit 1
+fi
+
+# grep out every "port": N line from launch.json
+PORTS=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$LAUNCH" | grep -oE '[0-9]+' | sort -u)
+
+if [[ -z "$PORTS" ]]; then
+  echo "no ports found in launch.json"
+  exit 0
+fi
+
+for port in $PORTS; do
+  pid=$(lsof -ti ":$port" -sTCP:LISTEN 2>/dev/null || true)
+  if [[ -z "$pid" ]]; then
+    echo "[skip] port $port: nothing listening"
+    continue
+  fi
+  echo "[kill] port $port: pid $pid"
+  kill "$pid" 2>/dev/null || true
+  sleep 0.2
+  # if still alive, force
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+    echo "       forced (SIGKILL)"
+  fi
+done


### PR DESCRIPTION
## Summary

Rescues a set of worktree setup scripts that had been living as untracked files in local working trees, plus the code-level changes the scripts assume exist. None of this was committed before — when the worktrees that hosted the scripts were cleaned up, the infra went with them, leaving every future worktree broken (no env file, no storage, no port isolation, no phone testing).

## What's in it

**Scripts**
- `scripts/setup-worktree.sh` — idempotent per-worktree bootstrap: picks a free port pair offset from main's 5174/3002, seeds `backend/.env` with matching `PORT` + `CORS_ORIGINS`, writes `frontend/.env.local` with `VITE_API_URL`/`VITE_SITE_URL`, writes `.claude/launch.json` with both frontend and backend entries, symlinks `backend/storage` to main's storage dir (so images load without duplication), adds the symlink to `.git/info/exclude`, runs `npm install` if needed. Supports `--force` and `--offset N`.
- `scripts/stop-worktree-servers.sh` — reads this worktree's launch.json ports and kills only those. Never touches main's servers.
- `frontend/scripts/dev-lan.mjs` + new `dev:lan` script in `frontend/package.json` — detects the Mac's LAN IP, rewrites `VITE_API_URL` to that IP, spawns vite with `--host 0.0.0.0`, prints the URL to open on your phone.

**Code changes the scripts assume exist**
- `backend/src/index.ts` — CORS middleware accepts any private-network origin (`localhost`, `10.x`, `192.168.x`, `172.16-31.x`) in non-prod. Without this, the phone can reach the backend TCP-wise but the browser blocks the cross-origin request.
- `frontend/src/api/client.ts` — when `VITE_API_URL` isn't set, derive the API base from `window.location.hostname` in dev. So loading the page from `192.168.1.62:5174` sends API calls to `192.168.1.62:3002` instead of `localhost:3002` (which on a phone is the phone itself).

## How worktrees work after this lands

1. `git worktree add .claude/worktrees/<name> -b claude/<name> main`
2. `cd .claude/worktrees/<name> && ./scripts/setup-worktree.sh`
3. In Claude Code: `preview_start backend`, `preview_start frontend`
4. For phone testing: `cd frontend && npm run dev:lan` (or bun), open the printed LAN URL on your phone.

## Test plan

- [ ] `./scripts/setup-worktree.sh` in a fresh worktree writes `backend/.env`, `frontend/.env.local`, `.claude/launch.json`, and the `backend/storage` symlink; subsequent runs are idempotent.
- [ ] `--force` regenerates env files; `--offset 15` pins ports at 5189/3017.
- [ ] `./scripts/stop-worktree-servers.sh` only kills processes on this worktree's ports, not main's.
- [ ] `npm run dev:lan` from `frontend/` prints the LAN IP and URL, vite binds to 0.0.0.0, phone on the same Wi-Fi can load the page and all API calls succeed.
- [ ] Main worktree still works on its fixed 5174/3002 ports (no env file means client.ts falls back to hostname-derived URL, which resolves to localhost when loaded from localhost).