### PR TITLE
Sticky Best Match sort, mobile swipe + LAN UUID fixes

### DIFF
--- a/frontend/src/components/SearchBar/SearchBar.test.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.test.tsx
@@ -9,6 +9,20 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+/**
+ * Find the letterDate sort option. `getByRole("option", { name: /Date/ })`
+ * is ambiguous because "Date Added" also matches, and the active option's
+ * accessible name includes a direction-arrow span. This targets the first
+ * child span text exactly.
+ */
+function getDateOption(): HTMLElement {
+  const list = screen.getByRole("listbox");
+  const options = within(list).getAllByRole("option");
+  const match = options.find((el) => el.querySelector("span")?.textContent === "Date");
+  if (!match) throw new Error("Date sort option not found");
+  return match;
+}
+
 describe("SearchBar", () => {
   const baseFacets: ArchiveSearchFacets = {
     formats: [{ value: "letter", label: "Letters", count: 12 }],
@@ -309,11 +323,71 @@ describe("SearchBar", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Sort archive results" }));
-    await user.click(screen.getByRole("option", { name: /Letter Date/i }));
+    // Exact-match "Date" so we don't accidentally hit "Date Added".
+    await user.click(getDateOption());
 
     expect(handleFiltersChange).toHaveBeenCalledWith({
       sort: "letterDate",
       sortOrder: "asc",
     });
+  });
+
+  it("shows Best Match in the sort dropdown even with no query", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SearchBar
+        query=""
+        filters={{}}
+        facets={baseFacets}
+        total={12}
+        loading={false}
+        onQueryChange={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Sort archive results" }));
+    expect(screen.getByRole("option", { name: /Best Match/i })).toBeInTheDocument();
+  });
+
+  it("does not auto-switch sort when the query changes", async () => {
+    const user = userEvent.setup();
+    const handleFiltersChange = vi.fn();
+
+    // Start with an explicit "Date" (letterDate) sort and no query.
+    const { rerender } = render(
+      <SearchBar
+        query=""
+        filters={{ sort: "letterDate", sortOrder: "desc" }}
+        facets={baseFacets}
+        total={12}
+        loading={false}
+        defaultSort="relevance"
+        onQueryChange={vi.fn()}
+        onFiltersChange={handleFiltersChange}
+      />,
+    );
+
+    // Simulate the user typing a query from the parent. Sort must NOT flip.
+    rerender(
+      <SearchBar
+        query="Molly"
+        filters={{ sort: "letterDate", sortOrder: "desc" }}
+        facets={baseFacets}
+        total={12}
+        loading={false}
+        defaultSort="relevance"
+        onQueryChange={vi.fn()}
+        onFiltersChange={handleFiltersChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Sort archive results" }));
+    const dateOption = getDateOption();
+    // The explicitly-chosen "Date" sort must still be the active option.
+    expect(dateOption).toHaveAttribute("aria-selected", "true");
+    // handleFiltersChange should not have been called from the query change.
+    expect(handleFiltersChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -8,7 +8,6 @@ import {
   COMBINED_SORT_OPTIONS,
   formatFacetLabel,
   getBestSuggestion,
-  getResolvedSort,
 } from "./searchBarUtils";
 import type { FilterChoiceOption } from "./searchBarUtils";
 import FilterChoiceField from "./FilterChoiceField";
@@ -30,6 +29,12 @@ interface SearchBarProps {
   searchTitle?: string;
   refineOpen?: boolean;
   sortOpen?: boolean;
+  /**
+   * Page-specific default sort used when the user hasn't explicitly picked
+   * one. "Best Match" is the default default — pages like collection detail
+   * pass "letterDate" to preserve chronological reading order.
+   */
+  defaultSort?: NonNullable<SearchFilters["sort"]>;
   dockTriggerRef?: Ref<HTMLDivElement>;
   onRefineOpenChange?: (open: boolean) => void;
   onSortOpenChange?: (open: boolean) => void;
@@ -69,6 +74,7 @@ export default function SearchBar({
   searchTitle,
   refineOpen,
   sortOpen: sortOpenProp,
+  defaultSort = "relevance",
   dockTriggerRef,
   onRefineOpenChange,
   onSortOpenChange,
@@ -214,7 +220,13 @@ export default function SearchBar({
     if (filters.verified !== undefined && filters.verified !== null) count++;
     return count;
   }, [filters, selectedFormats, isCompact, hideCollectionFilter]);
-  const resolvedSort = getResolvedSort(query, filters);
+  // Resolve the effective sort: user's explicit choice wins, otherwise the
+  // page default. This never depends on query presence — the sort the user
+  // sees should not silently flip when they start or stop typing.
+  const resolvedSort = {
+    sort: filters.sort || defaultSort,
+    sortOrder: filters.sortOrder || "desc",
+  };
 
   // Sort dropdown
   const [internalSortOpen, setInternalSortOpen] = useState(false);
@@ -225,10 +237,10 @@ export default function SearchBar({
     onSortOpenChange?.(next);
   };
   const visibleSortOptions = useMemo(() => {
-    let options = COMBINED_SORT_OPTIONS.filter((o) => !o.requiresQuery || hasQuery);
+    let options = COMBINED_SORT_OPTIONS;
     if (hideCollectionFilter) options = options.filter((o) => o.sort !== "collection");
     return options;
-  }, [hasQuery, hideCollectionFilter]);
+  }, [hideCollectionFilter]);
   const currentSortOption = visibleSortOptions.find((o) => o.sort === resolvedSort.sort);
   const showSortArrow = currentSortOption?.canToggle;
   const sortArrow = resolvedSort.sortOrder === "asc" ? "\u2191" : "\u2193";

--- a/frontend/src/components/SearchBar/searchBarUtils.ts
+++ b/frontend/src/components/SearchBar/searchBarUtils.ts
@@ -24,22 +24,21 @@ export type CombinedSortOption = {
   label: string;
   sort: NonNullable<SearchFilters["sort"]>;
   defaultOrder: NonNullable<SearchFilters["sortOrder"]>;
-  requiresQuery?: boolean;
   canToggle?: boolean;
 };
 
 export const SORT_FIELD_OPTIONS: SortFieldOption[] = [
   { label: "Best Match", value: "relevance", defaultOrder: "desc" },
   { label: "Publish Date", value: "createdAt", defaultOrder: "desc" },
-  { label: "Letter Date", value: "letterDate", defaultOrder: "desc" },
+  { label: "Date", value: "letterDate", defaultOrder: "desc" },
   { label: "Sender", value: "sender", defaultOrder: "asc" },
   { label: "Recipient", value: "recipient", defaultOrder: "asc" },
   { label: "Collection", value: "collection", defaultOrder: "asc" },
 ];
 
 export const COMBINED_SORT_OPTIONS: CombinedSortOption[] = [
-  { label: "Best Match", sort: "relevance", defaultOrder: "desc", requiresQuery: true },
-  { label: "Letter Date", sort: "letterDate", defaultOrder: "desc", canToggle: true },
+  { label: "Best Match", sort: "relevance", defaultOrder: "desc" },
+  { label: "Date", sort: "letterDate", defaultOrder: "desc", canToggle: true },
   { label: "Date Added", sort: "createdAt", defaultOrder: "desc", canToggle: true },
   { label: "Sender", sort: "sender", defaultOrder: "asc", canToggle: true },
   { label: "Recipient", sort: "recipient", defaultOrder: "asc", canToggle: true },
@@ -72,20 +71,8 @@ export const ARCHIVE_FORMAT_LABELS: Record<LetterImageType, string> = {
   voice: "Voice",
 };
 
-export function getResolvedSort(query: string, filters: SearchFilters) {
-  const hasQuery = Boolean(query.trim());
-  return {
-    sort: filters.sort || (hasQuery ? "relevance" : "createdAt"),
-    sortOrder: filters.sortOrder || "desc",
-  };
-}
-
 export function getSortValue(option: SortFieldOption) {
   return option.value;
-}
-
-export function getAvailableSortFields(hasQuery: boolean) {
-  return hasQuery ? SORT_FIELD_OPTIONS : SORT_FIELD_OPTIONS.filter((option) => option.value !== "relevance");
 }
 
 export function parseSortValue(value: string, options: SortFieldOption[]) {

--- a/frontend/src/content/blockFactories.ts
+++ b/frontend/src/content/blockFactories.ts
@@ -13,7 +13,23 @@ import type {
 } from './blocks';
 
 function uid(): string {
-  return crypto.randomUUID();
+  // crypto.randomUUID() requires a secure context — iOS Safari on a
+  // plain-http LAN URL (e.g. http://192.168.x.x) does not expose it, so
+  // fall back to a manual RFC4122-ish v4 via getRandomValues, and finally
+  // to Math.random when even that is unavailable.
+  const c = (globalThis as { crypto?: Crypto }).crypto;
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  if (c && typeof c.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    c.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+    return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+  }
+  // Last-resort: not cryptographically strong, but these ids are just
+  // local block keys, never security-sensitive.
+  return `uid-${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}`;
 }
 
 export function createHeroBlock(data?: Partial<Omit<HeroBlock, 'id' | 'type'>>): HeroBlock {

--- a/frontend/src/hooks/__tests__/useArchiveSearch.test.tsx
+++ b/frontend/src/hooks/__tests__/useArchiveSearch.test.tsx
@@ -116,3 +116,99 @@ describe('useArchiveSearch URL-param debounce', () => {
     expect(result.current.location.search).toBe('?q=molly');
   });
 });
+
+describe('useArchiveSearch sort resolution + URL omission', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolvedSort falls back to the page's defaultSort when filters.sort is unset", () => {
+    const { result: homeResult } = renderHook(
+      () => useArchiveSearch({ storageKey: 'test-home', defaultSort: 'relevance' }),
+      { wrapper: makeWrapper() },
+    );
+    expect(homeResult.current.resolvedSort).toBe('relevance');
+
+    const { result: collectionResult } = renderHook(
+      () =>
+        useArchiveSearch({
+          storageKey: 'test-collection',
+          defaultSort: 'letterDate',
+          defaultSortOrder: 'asc',
+        }),
+      { wrapper: makeWrapper() },
+    );
+    expect(collectionResult.current.resolvedSort).toBe('letterDate');
+  });
+
+  it('omits ?sort= from the URL when the chosen sort equals the page default (HomePage)', async () => {
+    const { result } = renderHook(
+      () => ({
+        archive: useArchiveSearch({ storageKey: 'test-home', defaultSort: 'relevance' }),
+        location: useLocation(),
+      }),
+      { wrapper: makeWrapper() },
+    );
+
+    // Default (relevance) — no URL param.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.location.search).toBe('');
+
+    // Pick a non-default sort → URL writes ?sort=letterDate.
+    act(() => {
+      result.current.archive.setFilters({ sort: 'letterDate', sortOrder: 'desc' });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.location.search).toBe('?sort=letterDate');
+
+    // Flip back to the default → URL drops ?sort=.
+    act(() => {
+      result.current.archive.setFilters({ sort: 'relevance', sortOrder: 'desc' });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.location.search).toBe('');
+  });
+
+  it('omits ?sort= when letterDate matches the CollectionDetailPage default', async () => {
+    const { result } = renderHook(
+      () => ({
+        archive: useArchiveSearch({
+          storageKey: 'test-collection',
+          defaultSort: 'letterDate',
+          defaultSortOrder: 'asc',
+        }),
+        location: useLocation(),
+      }),
+      { wrapper: makeWrapper() },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    // letterDate is the default sort field — ?sort= is omitted. (sortOrder=asc
+    // still appears because the hook hardcodes 'desc' as the omission threshold
+    // rather than comparing against defaultSortOrder — pre-existing behavior,
+    // tracked separately.)
+    expect(result.current.location.search).not.toContain('sort=letterDate');
+
+    // Pick Best Match → URL writes ?sort=relevance.
+    act(() => {
+      result.current.archive.setFilters({ sort: 'relevance', sortOrder: 'desc' });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.location.search).toContain('sort=relevance');
+  });
+});

--- a/frontend/src/hooks/__tests__/useArchiveSearch.test.tsx
+++ b/frontend/src/hooks/__tests__/useArchiveSearch.test.tsx
@@ -6,25 +6,27 @@ import useArchiveSearch from '../useArchiveSearch';
 
 // The hook fires searchArchiveShelf on a 180ms debounce. Stub it so the test
 // doesn't try to hit the real API; we only care about URL-param behavior here.
+const searchArchiveShelfMock = vi.fn(() =>
+  Promise.resolve({
+    letters: [],
+    page: 1,
+    limit: 24,
+    total: 0,
+    facets: {
+      formats: [],
+      collections: [],
+      correspondents: [],
+      places: [],
+      years: [],
+      topics: [],
+      tones: [],
+      relationships: [],
+    },
+  }),
+);
+
 vi.mock('../../api/letters', () => ({
-  searchArchiveShelf: vi.fn(() =>
-    Promise.resolve({
-      letters: [],
-      page: 1,
-      limit: 24,
-      total: 0,
-      facets: {
-        formats: [],
-        collections: [],
-        correspondents: [],
-        places: [],
-        years: [],
-        topics: [],
-        tones: [],
-        relationships: [],
-      },
-    }),
-  ),
+  searchArchiveShelf: (...args: unknown[]) => searchArchiveShelfMock(...(args as [])),
 }));
 
 // Isolate from real localStorage-backed persistence between tests.
@@ -178,6 +180,33 @@ describe('useArchiveSearch sort resolution + URL omission', () => {
       await vi.advanceTimersByTimeAsync(300);
     });
     expect(result.current.location.search).toBe('');
+  });
+
+  it('sends the resolved defaultSort to the backend when filters.sort is unset', async () => {
+    searchArchiveShelfMock.mockClear();
+
+    renderHook(
+      () =>
+        useArchiveSearch({
+          storageKey: 'test-collection-req',
+          defaultSort: 'letterDate',
+          defaultSortOrder: 'asc',
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    // Flush the 180ms request debounce.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(searchArchiveShelfMock).toHaveBeenCalled();
+    const lastCall = searchArchiveShelfMock.mock.calls.at(-1);
+    const params = (lastCall as unknown as [{ sort?: string; sortOrder?: string }])[0];
+    // Without this behavior, the UI shows "Date" as active while the backend
+    // silently serves relevance-ranked results — misleading sort cue.
+    expect(params.sort).toBe('letterDate');
+    expect(params.sortOrder).toBe('asc');
   });
 
   it('omits ?sort= when letterDate matches the CollectionDetailPage default', async () => {

--- a/frontend/src/hooks/useArchiveSearch.ts
+++ b/frontend/src/hooks/useArchiveSearch.ts
@@ -218,10 +218,15 @@ export default function useArchiveSearch(config: UseArchiveSearchConfig): UseArc
       yearTo: filters.dateRange?.end,
       hasTranscript: filters.hasTranscript,
       verified: filters.verified,
-      sort: filters.sort || undefined,
-      sortOrder: filters.sortOrder || undefined,
+      // Send the *resolved* sort so the backend matches the UI's active
+      // sort cue. Without this, an unset filters.sort makes the UI show the
+      // page default (e.g. letterDate on CollectionDetailPage) while the
+      // request falls through to the backend's own default, producing a
+      // stale/misleading sort indicator.
+      sort: filters.sort || defaultSort,
+      sortOrder: filters.sortOrder || defaultSortOrder,
     }),
-    [filters, searchQuery],
+    [filters, searchQuery, defaultSort, defaultSortOrder],
   );
 
   // ── Execute search (180ms debounce with request versioning) ──

--- a/frontend/src/hooks/useArchiveSearch.ts
+++ b/frontend/src/hooks/useArchiveSearch.ts
@@ -3,7 +3,11 @@ import { useSearchParams } from 'react-router-dom';
 import type { SearchFilters } from '../components/SearchBar/SearchBar';
 import { searchArchiveShelf, type ArchiveSearchResponse } from '../api/letters';
 import { saveSearchState, loadSearchState } from '../utils/searchPersistence';
-import { mergeArchiveItems, getResolvedArchiveSort } from '../utils/archiveSearch';
+import {
+  mergeArchiveItems,
+  getResolvedArchiveSort,
+  type ArchiveDefaultSort,
+} from '../utils/archiveSearch';
 
 const ARCHIVE_PAGE_SIZE = 24;
 
@@ -62,8 +66,8 @@ const FILTER_URL_KEYS = [
 export interface UseArchiveSearchConfig {
   /** localStorage key for persisting search state */
   storageKey: string;
-  /** Default sort when no query is active */
-  defaultSort?: 'createdAt' | 'letterDate';
+  /** Page-specific default sort when the user hasn't explicitly picked one. */
+  defaultSort?: ArchiveDefaultSort;
   /** Default sort order for the initial filter state */
   defaultSortOrder?: 'asc' | 'desc';
   /** Filters that are always enforced (e.g. { collection: "009" }). Excluded from URL params. */
@@ -86,7 +90,7 @@ export interface UseArchiveSearchReturn {
 }
 
 export default function useArchiveSearch(config: UseArchiveSearchConfig): UseArchiveSearchReturn {
-  const { storageKey, defaultSort = 'createdAt', defaultSortOrder, fixedFilters } = config;
+  const { storageKey, defaultSort = 'relevance', defaultSortOrder, fixedFilters } = config;
   const fixedKeys = useMemo(
     () => new Set(Object.keys(fixedFilters ?? {})),
     // fixedFilters identity is stable per call site — intentionally using JSON serialization
@@ -171,7 +175,10 @@ export default function useArchiveSearch(config: UseArchiveSearchConfig): UseArc
     if (filters.verified !== undefined && filters.verified !== null) {
       nextParams.set('verified', filters.verified ? 'true' : 'false');
     }
-    if (filters.sort && filters.sort !== 'relevance') nextParams.set('sort', filters.sort);
+    // Omit sort from the URL when it matches the page default — keeps
+    // canonical URLs clean (no ?sort=relevance on HomePage, no ?sort=letterDate
+    // on CollectionDetailPage).
+    if (filters.sort && filters.sort !== defaultSort) nextParams.set('sort', filters.sort);
     if (filters.sortOrder && filters.sortOrder !== 'desc') {
       nextParams.set('sortOrder', filters.sortOrder);
     }
@@ -185,7 +192,7 @@ export default function useArchiveSearch(config: UseArchiveSearchConfig): UseArc
     }, 250);
 
     return () => window.clearTimeout(timer);
-  }, [filters, fixedKeys, searchParams, searchQuery, setSearchParams]);
+  }, [filters, fixedKeys, searchParams, searchQuery, setSearchParams, defaultSort]);
 
   // ── Persist to localStorage (debounced) ──
   useEffect(() => {
@@ -279,7 +286,7 @@ export default function useArchiveSearch(config: UseArchiveSearchConfig): UseArc
   }, [archiveLoading, archiveLoadingMore, archiveResults, requestParams]);
 
   // ── Derived sort values ──
-  const resolvedSort = getResolvedArchiveSort(searchQuery, filters, defaultSort);
+  const resolvedSort = getResolvedArchiveSort(filters, defaultSort);
   const sortCueField: 'createdAt' | 'collection' | null =
     resolvedSort === 'createdAt' || resolvedSort === 'collection' ? resolvedSort : null;
 

--- a/frontend/src/hooks/useSwipeNavigation.ts
+++ b/frontend/src/hooks/useSwipeNavigation.ts
@@ -14,6 +14,30 @@ const DIRECTION_LOCK_PX = 20;
 const HORIZONTAL_RATIO = 1.8; // horizontal delta must exceed vertical by this factor
 const TRANSITION_MS = 280;
 
+// Text-like input types where horizontal drag is used for text selection, not swiping.
+const TEXT_INPUT_TYPES = new Set([
+  'text', 'search', 'email', 'url', 'tel', 'password', 'number',
+]);
+
+/**
+ * Returns true if the currently focused element is a text-editable control
+ * (text input, textarea, or contenteditable). Used to suppress page swipes
+ * while the user is interacting with text — horizontal drags there are
+ * text selection, not navigation.
+ */
+function isEditableElementFocused(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  if (tag === 'TEXTAREA') return true;
+  if (tag === 'INPUT') {
+    const type = ((el as HTMLInputElement).type || 'text').toLowerCase();
+    return TEXT_INPUT_TYPES.has(type);
+  }
+  return false;
+}
+
 interface UseSwipeNavigationOptions {
   onSwipeLeft?: () => void;   // finger moved left → "next"
   onSwipeRight?: () => void;  // finger moved right → "prev"
@@ -69,6 +93,10 @@ export default function useSwipeNavigation({
 
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length !== 1) return;
+
+      // If a text input / textarea / contenteditable is focused, horizontal
+      // drags are text selection — don't hijack them for page navigation.
+      if (isEditableElementFocused()) return;
 
       // Ignore touches inside child elements that handle their own gestures
       const target = e.target as HTMLElement;

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -426,6 +426,7 @@ export default function CollectionDetailPage() {
               embedded
               variant="full"
               hideCollectionFilter
+              defaultSort="letterDate"
               searchKicker={`Collection ${collection.collectionCode}`}
               searchTitle="Search This Collection"
               refineOpen={dock.pageRefineOpen}

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -31,7 +31,7 @@ type SortField = 'number' | 'letters' | 'date' | 'title';
 type SortOrder = 'asc' | 'desc';
 
 const SORT_OPTIONS: { field: SortField; label: string; defaultOrder: SortOrder }[] = [
-  { field: 'number', label: 'Collection #', defaultOrder: 'asc' },
+  { field: 'number', label: 'Collection', defaultOrder: 'asc' },
   { field: 'letters', label: 'Letter count', defaultOrder: 'desc' },
   { field: 'date', label: 'Date', defaultOrder: 'desc' },
   { field: 'title', label: 'Title', defaultOrder: 'asc' },

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -271,7 +271,7 @@ export default function HomePage() {
   const [latestBlogPost, setLatestBlogPost] = useState<BlogPost | null>(null);
 
   // ── Archive search (extracted hook) ──
-  const archive = useArchiveSearch({ storageKey: "home", defaultSort: "createdAt" });
+  const archive = useArchiveSearch({ storageKey: "home", defaultSort: "relevance" });
 
   // Freeze facets and total while a search is in flight so the SearchBar's
   // refine panel doesn't reshuffle counts between keystrokes (causes layout jumps).
@@ -497,6 +497,7 @@ export default function HomePage() {
           loading={archive.archiveLoading}
           embedded
           variant="full"
+          defaultSort="relevance"
           placeholder={isMobile ? "Search archive..." : undefined}
           refineOpen={dock.pageRefineOpen}
           sortOpen={dock.pageSortOpen}

--- a/frontend/src/pages/__tests__/CollectionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/CollectionsPage.test.tsx
@@ -74,10 +74,10 @@ describe("CollectionsPage", () => {
     );
     expect(titles[0]).toBe("War Letters");
 
-    // Open dropdown and click active "Collection #" to toggle to desc
+    // Open dropdown and click active "Collection" to toggle to desc
     await user.click(screen.getByLabelText("Sort collections"));
     let menuOptions = container.querySelectorAll(".sort-option");
-    await user.click(menuOptions[0]); // Collection # (active) — toggles to desc
+    await user.click(menuOptions[0]); // Collection (active) — toggles to desc
     titles = Array.from(container.querySelectorAll(".collection-card-top h3")).map((el) =>
       el.textContent?.trim(),
     );

--- a/frontend/src/pages/admin/adminCollectionPicker.ts
+++ b/frontend/src/pages/admin/adminCollectionPicker.ts
@@ -28,7 +28,7 @@ export const COLLECTION_PICKER_DEFAULT_SORT: CollectionPickerSortField = "letter
 export const COLLECTION_PICKER_DEFAULT_SORT_ORDER: CollectionPickerState["sortOrder"] = "desc";
 
 export const COLLECTION_PICKER_SORT_OPTIONS: CollectionPickerSortOption[] = [
-  { value: "letterDate", label: "Letter Date", defaultOrder: "desc" },
+  { value: "letterDate", label: "Date", defaultOrder: "desc" },
   { value: "sender", label: "Sender", defaultOrder: "asc" },
   { value: "recipient", label: "Recipient", defaultOrder: "asc" },
 ];

--- a/frontend/src/utils/archiveSearch.ts
+++ b/frontend/src/utils/archiveSearch.ts
@@ -20,16 +20,20 @@ export function mergeArchiveItems(
   return next;
 }
 
+export type ArchiveDefaultSort = 'relevance' | 'createdAt' | 'letterDate';
+
 /**
  * Resolve the effective sort field for archive search.
- * When there's an active text query, defaults to "relevance";
- * otherwise uses the provided defaultSort.
+ *
+ * If the user has explicitly picked a sort it wins, otherwise the page's
+ * defaultSort applies. We intentionally do NOT auto-switch based on query
+ * presence — the user's choice (or the page default) sticks regardless of
+ * whether they're searching, so their sort preference never silently flips
+ * out from under them.
  */
 export function getResolvedArchiveSort(
-  query: string,
   filters: SearchFilters,
-  defaultSort: 'createdAt' | 'letterDate' = 'createdAt',
+  defaultSort: ArchiveDefaultSort = 'relevance',
 ): string {
-  const hasQuery = Boolean(query.trim());
-  return filters.sort || (hasQuery ? 'relevance' : defaultSort);
+  return filters.sort || defaultSort;
 }


### PR DESCRIPTION
## Summary

Bundles four related frontend fixes touching sort UX, mobile interactions, and LAN dev parity.

### feat: sticky Best Match sort + label renames

Closes #17. Closes #18. Closes #31.

- **Best Match is now a first-class, always-visible sort option.** It no longer auto-switches based on query presence — whatever sort the user picks (or the page default) sticks across query changes. This was the core UX complaint: users felt "locked in" to relevance when searching and couldn't pre-select it from an empty state.
- **Per-page defaults** via a new ` defaultSort` prop: HomePage defaults to `relevance`, CollectionDetailPage keeps `letterDate asc` (preserves chronological reading). URL omits `?sort=` when the chosen sort matches the page default.
- **Label renames:** "Letter Date" → "Date" (archive + admin picker), "Collection #" → "Collection" (Collections index).
- **Dead code removed:** ` getResolvedSort`, ` getAvailableSortFields`, and the ` requiresQuery` flag. Sort resolution is now consolidated in ` getResolvedArchiveSort`.
- No backend changes — [backend/src/routes/letters.ts:1495](backend/src/routes/letters.ts#L1495) already maps ` sort=relevance + empty query` → ` createdAt DESC`.

### fix: mobile swipe suppression while text input is focused (closes #27)

` useSwipeNavigation` now bails out of ` touchstart` when the active element is a text input, textarea, or contenteditable. Prevents the archive search field on mobile from triggering page swipes while you're typing.

### fix: ` crypto.randomUUID` fallback for LAN dev

iOS Safari only exposes ` crypto.randomUUID` in secure contexts (HTTPS or localhost). LAN dev over ` http://192.168.x.x` broke block creation in ` blockFactories.ts`. Added a chain: ` randomUUID` → ` getRandomValues` (manual v4) → ` Math.random` fallback. No effect on production.

### test: sticky sort + URL omission coverage

Added tests in ` useArchiveSearch.test.tsx` covering:
- ` resolvedSort` falls back to the page's ` defaultSort` when filters.sort is unset
- HomePage URL omits ` ?sort=` by default, writes ` ?sort=letterDate` on pick, drops it again when flipped back
- CollectionDetailPage URL omits ` ?sort=letterDate` by default and writes ` ?sort=relevance` for Best Match

Updated ` SearchBar.test.tsx`:
- Helper ` getDateOption()` disambiguates the renamed "Date" option from "Date Added"
- New test: Best Match visible in dropdown with empty query
- New test: sort does NOT auto-switch when the query changes

## Reviewer notes

- **Pre-existing sortOrder inconsistency, not fixed here:** [useArchiveSearch.ts:182](frontend/src/hooks/useArchiveSearch.ts#L182) hardcodes ` 'desc'` as the sortOrder omission threshold rather than comparing against ` defaultSortOrder`. On CollectionDetailPage this writes a stray ` ?sortOrder=asc` even though asc matches the page default. Flagged in a test comment; happy to file a follow-up.
- Follow-up issue already filed: MLGalusha/letter-archive#32 (remove dead ` SORT_FIELD_OPTIONS` / ` getSortValue` / ` parseSortValue`).
- Follow-ups previously filed and out of scope here: #29 (curated empty-query Best Match ranking), #30 (Popular sort with tracking infra).

## Test plan

- [x] Frontend unit tests pass (SearchBar, CollectionsPage, useArchiveSearch)
- [x] ` tsc -b` clean
- [x] Manual smoke: HomePage default → Best Match, no ` ?sort=`; pick Date + query "molly" → sort sticks, URL = ` ?q=molly&sort=letterDate`
- [x] Manual smoke: ` /collections/001` default → Date asc, no ` ?sort=`; query "jimmie" → sort stays Date (does NOT flip to Best Match)
- [x] Manual smoke: Collections index shows "Collection" label (no ` #`)
- [ ] Reviewer: confirm mobile swipe no longer fires while the archive search input is focused on a real iOS device
- [ ] Reviewer: confirm about/support pages load over LAN dev on iOS without the ` crypto.randomUUID` dev error
