### PR TITLE
Mobile padding fix + Reader View V2 refactor

### DIFF
--- a/backend/src/ai/openai/boundaryClassifier.ts
+++ b/backend/src/ai/openai/boundaryClassifier.ts
@@ -1,0 +1,195 @@
+/**
+ * Boundary Classifier (Reader View V2)
+ *
+ * Narrow structural classifier that determines how adjacent body text lines
+ * relate to each other. Uses the same tool-calling pattern as breakMap.ts
+ * to guarantee the AI cannot modify transcript text.
+ *
+ * Input:  Unprotected body text lines (standalone blocks already excluded)
+ * Output: Boundary decisions between consecutive lines
+ */
+
+import { hasOpenAI } from '../../config/env.js';
+import { log, openai } from './client.js';
+import { logApiUsage } from '../../services/usage-tracking.js';
+import type { ReaderSourceLine, ReaderDecision, BoundaryDecision } from '../../types/readerView.js';
+
+const MODEL = 'gpt-5.4-mini';
+
+const SYSTEM_PROMPT = `You are analyzing the structure of a historical handwritten letter transcript.
+You will receive a list of body text lines (standalone structural elements like dates, salutations, closings, and signatures have already been removed).
+
+For each BOUNDARY between consecutive lines, classify the structural relationship.
+
+Rules:
+- "join_with_space": These lines are part of the same paragraph. The line break is just where the writer's hand hit the edge of the paper.
+- "join_remove_hyphen": The previous line ends with a hyphenated word break (e.g. "to-" + "morrow" → "tomorrow"). Join without space and remove the hyphen.
+- "new_paragraph": A new paragraph starts here. The writer shifted topic, indented, or started a new thought.
+- "uncertain": You cannot tell. Preserve the original line break.
+
+Important:
+- Do NOT rewrite or modify any text. You are classifying structure only.
+- Page breaks do NOT automatically mean paragraph breaks. Paragraphs frequently continue across pages.
+- When uncertain, use "uncertain" — it is better to preserve a break than to wrongly join.
+- Blank lines have already been removed and treated as paragraph breaks. You will not see them.
+- Indent changes often (but not always) indicate new paragraphs.`;
+
+const BOUNDARY_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'classify_boundaries',
+    description: 'Classify the structural relationship at each boundary between consecutive lines.',
+    parameters: {
+      type: 'object' as const,
+      properties: {
+        decisions: {
+          type: 'array' as const,
+          description: 'One entry per boundary (between line N and line N+1). Array length should be (number of lines - 1).',
+          items: {
+            type: 'object' as const,
+            properties: {
+              afterLineId: {
+                type: 'string' as const,
+                description: 'The ID of the line BEFORE this boundary.',
+              },
+              decision: {
+                type: 'string' as const,
+                enum: ['join_with_space', 'join_remove_hyphen', 'new_paragraph', 'uncertain'],
+              },
+            },
+            required: ['afterLineId', 'decision'],
+          },
+        },
+      },
+      required: ['decisions'],
+    },
+  },
+};
+
+/**
+ * Heuristic fallback when AI is unavailable.
+ * Conservative: treats indent changes as paragraph breaks, everything else as joins.
+ */
+function heuristicBoundaries(lines: ReaderSourceLine[]): BoundaryDecision[] {
+  const decisions: BoundaryDecision[] = [];
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    const current = lines[i];
+    const next = lines[i + 1];
+
+    let decision: ReaderDecision;
+
+    // Hyphenation
+    if (current.text.trim().match(/[a-zA-Z]-$/) && next.text.trim().match(/^[a-z]/)) {
+      decision = 'join_remove_hyphen';
+    }
+    // Indent change suggests new paragraph
+    else if (next.indentHint !== 'none' && current.indentHint === 'none') {
+      decision = 'new_paragraph';
+    }
+    // Short line followed by normal line might be end of paragraph
+    else if (current.text.trim().length < 30 && next.text.trim().length > 50) {
+      decision = 'new_paragraph';
+    }
+    // Default: join
+    else {
+      decision = 'join_with_space';
+    }
+
+    decisions.push({ afterLineId: current.id, decision });
+  }
+
+  return decisions;
+}
+
+/**
+ * Classify boundaries between body text lines using AI.
+ * Falls back to heuristics if AI is unavailable.
+ */
+export async function classifyBoundaries(
+  lines: ReaderSourceLine[],
+  letterId?: string,
+): Promise<BoundaryDecision[]> {
+  if (lines.length <= 1) return [];
+
+  // Very short texts don't need AI
+  if (lines.length <= 4) {
+    return heuristicBoundaries(lines);
+  }
+
+  if (!openai) {
+    log.info({ letterId }, 'No OpenAI key — using heuristic boundary classification');
+    return heuristicBoundaries(lines);
+  }
+
+  // Build structured input for the AI
+  const lineDescriptions = lines.map(line => {
+    const parts = [`[${line.id}]`];
+    if (line.pageBreakBefore) parts.push('[PAGE BREAK ABOVE]');
+    if (line.indentHint !== 'none') parts.push(`[indent:${line.indentHint}]`);
+    parts.push(line.text.trim());
+    return parts.join(' ');
+  }).join('\n');
+
+  const start = Date.now();
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: lineDescriptions },
+      ],
+      tools: [BOUNDARY_TOOL],
+      tool_choice: { type: 'function', function: { name: 'classify_boundaries' } },
+      temperature: 0,
+    });
+
+    const durationMs = Date.now() - start;
+    const usage = response.usage;
+
+    if (usage) {
+      logApiUsage({
+        letterId,
+        callType: 'boundary_classifier',
+        model: MODEL,
+        inputTokens: usage.prompt_tokens ?? 0,
+        outputTokens: usage.completion_tokens ?? 0,
+        durationMs,
+      });
+    }
+
+    const toolCall = response.choices[0]?.message?.tool_calls?.[0];
+    if (!toolCall || toolCall.function.name !== 'classify_boundaries') {
+      log.warn({ letterId }, 'AI did not call classify_boundaries — falling back to heuristic');
+      return heuristicBoundaries(lines);
+    }
+
+    const args = JSON.parse(toolCall.function.arguments) as {
+      decisions: { afterLineId: string; decision: string }[];
+    };
+
+    // Validate and filter decisions
+    const validDecisions = new Set<string>([
+      'join_with_space', 'join_remove_hyphen', 'new_paragraph', 'uncertain',
+    ]);
+    const validLineIds = new Set(lines.map(l => l.id));
+
+    const decisions: BoundaryDecision[] = (args.decisions ?? [])
+      .filter(d => validLineIds.has(d.afterLineId) && validDecisions.has(d.decision))
+      .map(d => ({
+        afterLineId: d.afterLineId,
+        decision: d.decision as ReaderDecision,
+      }));
+
+    log.info(
+      { letterId, lineCount: lines.length, decisionCount: decisions.length, durationMs },
+      'Boundary classification complete',
+    );
+
+    return decisions;
+  } catch (err) {
+    log.warn({ letterId, err }, 'Boundary classification AI call failed — falling back to heuristic');
+    return heuristicBoundaries(lines);
+  }
+}

--- a/backend/src/db/migrations/0045_reader_view_v2.sql
+++ b/backend/src/db/migrations/0045_reader_view_v2.sql
@@ -1,0 +1,4 @@
+-- Reader View V2: segment classifications and derived reader blocks
+ALTER TABLE "letter_pages" ADD COLUMN "segment_classifications" jsonb;
+ALTER TABLE "letters" ADD COLUMN "reader_blocks" jsonb;
+ALTER TABLE "letters" ADD COLUMN "reader_decisions" jsonb;

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1776422400000,
       "tag": "0044_add_extra_content_job_status",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1776508800000,
+      "tag": "0045_reader_view_v2",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -251,6 +251,10 @@ export const letters = pgTable(
     // Reading view text (independent spacing from raw transcript)
     readingText: text('reading_text'),
 
+    // Reader View V2: derived block-based rendering
+    readerBlocks: jsonb('reader_blocks'),
+    readerDecisions: jsonb('reader_decisions'),
+
     // Admin review
     reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
     reviewedBy: text('reviewed_by'),
@@ -306,6 +310,7 @@ export const letterPages = pgTable(
     checksumSha256: text('checksum_sha256'),
     lineSegments: jsonb('line_segments'),
     segmentTrustState: text('segment_trust_state').notNull().default('unverified'),
+    segmentClassifications: jsonb('segment_classifications'),
     width: integer('width'),
     height: integer('height'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/backend/src/dto/letter.dto.ts
+++ b/backend/src/dto/letter.dto.ts
@@ -200,6 +200,8 @@ export interface FrontendLetter {
   aiNotes?: unknown;
   // Reading view text (independent spacing from raw transcript)
   readingText?: string;
+  // Reader View V2: derived block-based rendering
+  readerBlocks?: unknown[];
   // Legacy field kept for backward compat
   transcriptConfirmedAt?: string;
   flagged: boolean;
@@ -540,6 +542,8 @@ export function transformLetterToDTO(letter: LetterWithRelations): FrontendLette
     aiNotes: letter.aiNotes || undefined,
     // Reading view text
     readingText: letter.readingText || undefined,
+    // Reader View V2
+    readerBlocks: (letter.readerBlocks as unknown[] | null) || undefined,
     // Entity extraction (Prompt 2)
     entityExtractionStatus: letter.entityExtractionStatus || undefined,
     entityExtractionJson: letter.entityExtractionJson || undefined,

--- a/backend/src/routes/admin/letters/content.ts
+++ b/backend/src/routes/admin/letters/content.ts
@@ -26,6 +26,7 @@ import { addAliasToCanonicalPerson } from '../../../services/entities/persons.js
 import { syncLetterParticipantsFromMetadata } from '../../../services/entities/participant-sync.js';
 import { getAbsoluteStoragePath } from '../../../services/storage.js';
 import { runEntityExtractionOnly, runMetadataExtractionV2, type ExtractionOptions } from '../../../pipeline/metadataV2.js';
+import type { SegmentClass, SegmentClassification } from '../../../types/readerView.js';
 import { BadRequestError, NotFoundError } from '../../../utils/response-helpers.js';
 import { isPlaceholderValue } from '../../../utils/placeholders.js';
 import {
@@ -752,6 +753,43 @@ router.patch('/:letterId/segment-trust', async (req, res, next) => {
 
     req.log.info({ letterId: req.params.letterId, trustState, pageCount: pages.length }, 'Segment trust state updated for all pages');
     res.json({ ok: true, trustState, pageCount: pages.length });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Save segment classifications for a page
+const VALID_SEGMENT_CLASSES: SegmentClass[] = ['body', 'continuation', 'addition', 'ignore'];
+
+router.patch('/pages/:pageId/segment-classifications', async (req, res, next) => {
+  try {
+    const page = await db.query.letterPages.findFirst({
+      where: eq(letterPages.id, req.params.pageId),
+    });
+    if (!page) throw new NotFoundError('Page not found');
+
+    const { classifications } = req.body;
+    if (!classifications || typeof classifications !== 'object' || Array.isArray(classifications)) {
+      throw new BadRequestError('classifications must be an object mapping segment index to classification');
+    }
+
+    // Validate each entry
+    for (const [key, val] of Object.entries(classifications)) {
+      if (isNaN(Number(key))) {
+        throw new BadRequestError(`Invalid segment index: ${key}`);
+      }
+      const c = val as SegmentClassification;
+      if (!c.class || !VALID_SEGMENT_CLASSES.includes(c.class)) {
+        throw new BadRequestError(`Invalid class for segment ${key}: ${c.class}`);
+      }
+    }
+
+    await db.update(letterPages)
+      .set({ segmentClassifications: classifications, updatedAt: new Date() })
+      .where(eq(letterPages.id, req.params.pageId));
+
+    req.log.info({ pageId: req.params.pageId, count: Object.keys(classifications).length }, 'Segment classifications updated');
+    res.json({ ok: true });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/admin/letters/content.ts
+++ b/backend/src/routes/admin/letters/content.ts
@@ -27,6 +27,7 @@ import { syncLetterParticipantsFromMetadata } from '../../../services/entities/p
 import { getAbsoluteStoragePath } from '../../../services/storage.js';
 import { runEntityExtractionOnly, runMetadataExtractionV2, type ExtractionOptions } from '../../../pipeline/metadataV2.js';
 import type { SegmentClass, SegmentClassification } from '../../../types/readerView.js';
+import { deriveAndSaveReaderBlocks } from '../../../services/letter/readerDerivation.js';
 import { BadRequestError, NotFoundError } from '../../../utils/response-helpers.js';
 import { isPlaceholderValue } from '../../../utils/placeholders.js';
 import {
@@ -790,6 +791,19 @@ router.patch('/pages/:pageId/segment-classifications', async (req, res, next) =>
 
     req.log.info({ pageId: req.params.pageId, count: Object.keys(classifications).length }, 'Segment classifications updated');
     res.json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Derive reader blocks for a letter (Reader View V2)
+router.post('/:letterId/derive-reader-blocks', async (req, res, next) => {
+  try {
+    const blocks = await deriveAndSaveReaderBlocks(req.params.letterId);
+    if (!blocks) {
+      throw new NotFoundError('Letter not found or has no transcript');
+    }
+    res.json({ ok: true, blocks });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/letters.ts
+++ b/backend/src/routes/letters.ts
@@ -274,6 +274,8 @@ router.get('/letters', async (req, res, next) => {
         metadataJson: false,
         aiNotes: false,
         readingText: false,
+        readerBlocks: false,
+        readerDecisions: false,
         extraContentTranscript: false,
       },
       with: {

--- a/backend/src/services/letter/readerDerivation.ts
+++ b/backend/src/services/letter/readerDerivation.ts
@@ -1,0 +1,530 @@
+/**
+ * Reader Derivation Pipeline (V2)
+ *
+ * Derives reader blocks from canonical transcript text + optional metadata.
+ * The transcript text is never modified — only structural decisions are made
+ * about how to assemble it into readable blocks.
+ *
+ * Pipeline:
+ *   1. normalizeToSourceLines — split transcript into normalized lines
+ *   2. buildProtectedBlocks — deterministic standalone block identification
+ *   3. AI boundary classifier — narrow structural classification (ambiguous body text only)
+ *   4. assembleReaderBlocks — build final blocks from lines + decisions
+ */
+
+import { eq } from 'drizzle-orm';
+import { db, letters, letterPages } from '../../db/index.js';
+import { getLetterById } from '../letters.js';
+import { log } from './shared.js';
+import { classifyBoundaries } from '../../ai/openai/boundaryClassifier.js';
+import type {
+  ReaderSourceLine,
+  ReaderBlock,
+  ReaderBlockType,
+  ReaderDecision,
+  BoundaryDecision,
+} from '../../types/readerView.js';
+
+/** Page divider pattern used in multi-page transcripts */
+const PAGE_DIVIDER_RE = /^-{2,}\s*Page\s+\d+\s*-{2,}$/i;
+
+/* ── Step 1: Normalize transcript to source lines ─────────── */
+
+interface StructuredPageData {
+  pageNumber: number;
+  lines: { text: string; role: string | null; areaId?: number | null }[];
+  specialAreas?: { id: number; type: 'continuation' | 'addition' }[];
+}
+
+/**
+ * Normalize a letter's transcript into source lines.
+ * Uses transcriptionText as canonical source, enhanced with metadata
+ * from transcriptionJson (roles, special areas) when available.
+ */
+export function normalizeToSourceLines(
+  transcriptText: string,
+  structuredPages?: StructuredPageData[],
+): ReaderSourceLine[] {
+  const rawLines = transcriptText.split('\n');
+  const lines: ReaderSourceLine[] = [];
+
+  let pageNumber = 1;
+  let orderInPage = 0;
+  let prevWasPageBreak = false;
+
+  // Build a lookup of structured line data by page
+  const structuredLookup = new Map<number, StructuredPageData>();
+  const specialAreaTypes = new Map<number, 'continuation' | 'addition'>();
+  if (structuredPages) {
+    for (const sp of structuredPages) {
+      structuredLookup.set(sp.pageNumber, sp);
+      if (sp.specialAreas) {
+        for (const area of sp.specialAreas) {
+          specialAreaTypes.set(area.id, area.type);
+        }
+      }
+    }
+  }
+
+  for (let i = 0; i < rawLines.length; i++) {
+    const raw = rawLines[i];
+
+    // Skip page divider lines
+    if (PAGE_DIVIDER_RE.test(raw.trim())) {
+      pageNumber++;
+      orderInPage = 0;
+      prevWasPageBreak = true;
+      continue;
+    }
+
+    const text = raw; // preserve exact text including leading whitespace
+    const trimmed = raw.trim();
+    const isBlank = trimmed === '';
+
+    // Compute indent hint from leading whitespace
+    const leadingSpaces = raw.length - raw.trimStart().length;
+    let indentHint: 'none' | 'small' | 'large' = 'none';
+    if (leadingSpaces >= 8) indentHint = 'large';
+    else if (leadingSpaces >= 3) indentHint = 'small';
+
+    // Look up structured metadata for this line
+    let roleHint: ReaderBlockType | 'body' | undefined;
+    let specialAreaHint: 'continuation' | 'addition' | undefined;
+
+    const structuredPage = structuredLookup.get(pageNumber);
+    if (structuredPage && orderInPage < structuredPage.lines.length) {
+      const sl = structuredPage.lines[orderInPage];
+      if (sl.role) {
+        roleHint = mapRoleToBlockType(sl.role);
+      }
+      if (sl.areaId != null) {
+        specialAreaHint = specialAreaTypes.get(sl.areaId);
+      }
+    }
+
+    const id = `p${pageNumber}-L${orderInPage + 1}`;
+
+    lines.push({
+      id,
+      pageNumber,
+      order: orderInPage,
+      text,
+      isBlank,
+      pageBreakBefore: prevWasPageBreak,
+      pageBreakAfter: false, // set below
+      indentHint,
+      roleHint,
+      specialAreaHint,
+    });
+
+    prevWasPageBreak = false;
+    orderInPage++;
+  }
+
+  // Set pageBreakAfter by looking at the next line
+  for (let i = 0; i < lines.length - 1; i++) {
+    if (lines[i + 1].pageBreakBefore) {
+      lines[i].pageBreakAfter = true;
+    }
+  }
+
+  return lines;
+}
+
+function mapRoleToBlockType(role: string): ReaderBlockType | 'body' {
+  const map: Record<string, ReaderBlockType> = {
+    date: 'date',
+    salutation: 'salutation',
+    closing: 'closing',
+    signature: 'signature',
+    postscript: 'postscript',
+    address: 'address',
+    ps: 'postscript',
+  };
+  return map[role.toLowerCase()] ?? 'body';
+}
+
+/* ── Step 2: Deterministic protected block identification ──── */
+
+interface ProtectedRange {
+  startIdx: number;
+  endIdx: number;
+  type: ReaderBlockType;
+}
+
+/**
+ * Identify lines that should NOT be collapsed into body paragraphs.
+ * Returns index ranges of protected blocks plus their types.
+ */
+export function identifyProtectedBlocks(lines: ReaderSourceLine[]): ProtectedRange[] {
+  const protectedRanges: ProtectedRange[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.isBlank) continue;
+
+    // Structural roles from metadata
+    if (line.roleHint && line.roleHint !== 'body') {
+      const type = line.roleHint as ReaderBlockType;
+      // Extend if consecutive lines have the same role
+      const existing = protectedRanges[protectedRanges.length - 1];
+      if (existing && existing.type === type && existing.endIdx === i - 1) {
+        existing.endIdx = i;
+      } else {
+        protectedRanges.push({ startIdx: i, endIdx: i, type });
+      }
+      continue;
+    }
+
+    // Special area hints
+    if (line.specialAreaHint) {
+      const type = line.specialAreaHint as ReaderBlockType;
+      const existing = protectedRanges[protectedRanges.length - 1];
+      if (existing && existing.type === type && existing.endIdx === i - 1) {
+        existing.endIdx = i;
+      } else {
+        protectedRanges.push({ startIdx: i, endIdx: i, type });
+      }
+      continue;
+    }
+
+    // Heuristic detection for common standalone patterns
+    const trimmed = line.text.trim();
+
+    // Date patterns (short line at start with date-like content)
+    if (i <= 2 && !lines.slice(0, i).some(l => !l.isBlank) && looksLikeDate(trimmed)) {
+      protectedRanges.push({ startIdx: i, endIdx: i, type: 'date' });
+      continue;
+    }
+
+    // Salutation: "Dear ...", "My dear ...", "Dearest ..."
+    if (/^(Dear|My\s+dear|Dearest)\b/i.test(trimmed) && trimmed.length < 80) {
+      protectedRanges.push({ startIdx: i, endIdx: i, type: 'salutation' });
+      continue;
+    }
+
+    // Closing patterns: "Love,", "Sincerely,", "Yours truly,", etc.
+    if (looksLikeClosing(trimmed)) {
+      protectedRanges.push({ startIdx: i, endIdx: i, type: 'closing' });
+      continue;
+    }
+
+    // Signature: short line (1-3 words) after a closing
+    const prevProtected = protectedRanges[protectedRanges.length - 1];
+    if (
+      prevProtected?.type === 'closing' &&
+      prevProtected.endIdx >= i - 2 && // within 2 lines of closing
+      trimmed.length > 0 &&
+      trimmed.split(/\s+/).length <= 4 &&
+      !trimmed.endsWith(',')
+    ) {
+      protectedRanges.push({ startIdx: i, endIdx: i, type: 'signature' });
+      continue;
+    }
+
+    // Postscript: "P.S.", "PS:", "P.P.S."
+    if (/^P\.?S\.?\s*[:-]?/i.test(trimmed) || /^P\.?P\.?S\.?\s*[:-]?/i.test(trimmed)) {
+      protectedRanges.push({ startIdx: i, endIdx: i, type: 'postscript' });
+      continue;
+    }
+  }
+
+  return protectedRanges;
+}
+
+function looksLikeDate(text: string): boolean {
+  if (text.length > 60) return false;
+  // Common date patterns in historical letters
+  return /\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|June|July|August|September|October|November|December)\b/i.test(text) ||
+    /\b\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{2,4}\b/.test(text) ||
+    /\b\d{4}\b/.test(text) && text.split(/\s+/).length <= 6;
+}
+
+function looksLikeClosing(text: string): boolean {
+  if (text.length > 60) return false;
+  const closingPatterns = [
+    /^(Love|Much love|All my love|With love|Lovingly|Fondly)\b/i,
+    /^(Sincerely|Yours sincerely|Very sincerely)\b/i,
+    /^(Yours truly|Yours|Very truly yours)\b/i,
+    /^(Affectionately|With affection)\b/i,
+    /^(Best wishes|Best regards|Regards|Warmly)\b/i,
+    /^(As ever|As always|Ever yours)\b/i,
+    /^(Your loving|Your devoted|Your affectionate)\b/i,
+    /^(God bless|Take care)\b/i,
+  ];
+  return closingPatterns.some(p => p.test(text));
+}
+
+/* ── Step 3: Assemble reader blocks ──────────────────────── */
+
+/**
+ * Build reader blocks from source lines and boundary decisions.
+ */
+export function assembleReaderBlocks(
+  lines: ReaderSourceLine[],
+  protectedRanges: ProtectedRange[],
+  decisions: BoundaryDecision[],
+): ReaderBlock[] {
+  const blocks: ReaderBlock[] = [];
+
+  // Build a set of protected line indices
+  const protectedMap = new Map<number, ProtectedRange>();
+  for (const range of protectedRanges) {
+    for (let i = range.startIdx; i <= range.endIdx; i++) {
+      protectedMap.set(i, range);
+    }
+  }
+
+  // Build decision lookup
+  const decisionMap = new Map<string, ReaderDecision>();
+  for (const d of decisions) {
+    decisionMap.set(d.afterLineId, d.decision);
+  }
+
+  let currentLines: ReaderSourceLine[] = [];
+  let currentType: ReaderBlockType = 'paragraph';
+  let blockCounter = 0;
+
+  function flushBlock() {
+    if (currentLines.length === 0) return;
+    const nonBlank = currentLines.filter(l => !l.isBlank);
+    if (nonBlank.length === 0) {
+      currentLines = [];
+      return;
+    }
+    blockCounter++;
+    blocks.push({
+      id: `block-${blockCounter}`,
+      type: currentType,
+      lineIds: nonBlank.map(l => l.id),
+      text: joinLines(nonBlank),
+      alignment: inferAlignment(nonBlank, currentType),
+    });
+    currentLines = [];
+    currentType = 'paragraph';
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Skip blank lines — they always create a paragraph break
+    if (line.isBlank) {
+      flushBlock();
+      continue;
+    }
+
+    // Check if this line is in a protected range
+    const protectedRange = protectedMap.get(i);
+    if (protectedRange) {
+      // If we were accumulating body text, flush it first
+      if (currentType === 'paragraph' && currentLines.length > 0 && currentType !== protectedRange.type) {
+        flushBlock();
+      }
+
+      // If starting a new protected block
+      if (currentType !== protectedRange.type || currentLines.length === 0) {
+        if (currentLines.length > 0) flushBlock();
+        currentType = protectedRange.type;
+      }
+      currentLines.push(line);
+
+      // If this is the last line of the protected range, flush
+      if (i === protectedRange.endIdx) {
+        flushBlock();
+      }
+      continue;
+    }
+
+    // Body text — check boundary decision from previous line
+    if (currentLines.length > 0) {
+      const prevLine = currentLines[currentLines.length - 1];
+      const decision = decisionMap.get(prevLine.id) ?? inferDefaultDecision(prevLine, line);
+
+      switch (decision) {
+        case 'new_paragraph':
+        case 'keep_separate_block':
+        case 'uncertain':
+          flushBlock();
+          break;
+        case 'join_remove_hyphen':
+        case 'join_with_space':
+        case 'continues_special_area':
+          // continue accumulating
+          break;
+      }
+    }
+
+    currentType = 'paragraph';
+    currentLines.push(line);
+  }
+
+  flushBlock();
+  return blocks;
+}
+
+/**
+ * Default decision when AI hasn't classified a boundary.
+ * Conservative: blank lines and large indentation changes = new paragraph.
+ */
+function inferDefaultDecision(prev: ReaderSourceLine, next: ReaderSourceLine): ReaderDecision {
+  // Page break without other signals: join (paragraphs often span pages)
+  // Large indent change: likely new paragraph
+  if (next.indentHint === 'large' && prev.indentHint === 'none') {
+    return 'new_paragraph';
+  }
+  if (next.indentHint === 'small' && prev.indentHint === 'none') {
+    return 'new_paragraph';
+  }
+
+  // Hyphenated continuation
+  if (prev.text.trim().match(/[a-zA-Z]-$/) && next.text.trim().match(/^[a-z]/)) {
+    return 'join_remove_hyphen';
+  }
+
+  return 'join_with_space';
+}
+
+/**
+ * Join lines into text, handling hyphenation.
+ */
+function joinLines(lines: ReaderSourceLine[]): string {
+  if (lines.length === 0) return '';
+  if (lines.length === 1) return lines[0].text.trim();
+
+  let result = lines[0].text.trim();
+  for (let i = 1; i < lines.length; i++) {
+    const nextText = lines[i].text.trim();
+    if (result.match(/[a-zA-Z]-$/) && nextText.match(/^[a-z]/)) {
+      result = result.slice(0, -1) + nextText;
+    } else {
+      result = result + ' ' + nextText;
+    }
+  }
+  return result;
+}
+
+function inferAlignment(
+  lines: ReaderSourceLine[],
+  type: ReaderBlockType,
+): ReaderBlock['alignment'] {
+  // Date, closing, signature often right-shifted
+  if (type === 'date' || type === 'closing' || type === 'signature') {
+    const avgIndent = lines.reduce((sum, l) => sum + (l.text.length - l.text.trimStart().length), 0) / lines.length;
+    if (avgIndent >= 8) return 'right-shifted';
+  }
+  if (type === 'continuation' || type === 'addition') return 'aside';
+  if (lines.length > 0 && lines[0].indentHint !== 'none') return 'indented';
+  return 'left';
+}
+
+/* ── Step 4: Orchestration ──────────────────────────────── */
+
+/**
+ * Derive reader blocks for a letter and save to database.
+ */
+export async function deriveAndSaveReaderBlocks(letterId: string): Promise<ReaderBlock[] | null> {
+  const letter = await getLetterById(letterId);
+  if (!letter) {
+    log.warn({ letterId }, 'Letter not found for reader derivation');
+    return null;
+  }
+
+  if (!letter.transcriptionText) {
+    log.warn({ letterId }, 'No transcript — cannot derive reader blocks');
+    return null;
+  }
+
+  log.info({ letterId }, 'Starting reader block derivation');
+
+  // Get structured page data if available
+  const structuredPages = letter.transcriptionJson
+    ? (letter.transcriptionJson as { pages: StructuredPageData[] }).pages
+    : undefined;
+
+  // Get segment classifications for trusted pages
+  const pages = await db.query.letterPages.findMany({
+    where: eq(letterPages.letterId, letterId),
+    columns: {
+      pageNumber: true,
+      segmentTrustState: true,
+      segmentClassifications: true,
+      lineSegments: true,
+    },
+  });
+
+  // Step 1: Normalize
+  const sourceLines = normalizeToSourceLines(letter.transcriptionText, structuredPages);
+
+  // Enhance with trusted segment data
+  for (const page of pages) {
+    if (page.segmentTrustState !== 'trusted') continue;
+    const segments = page.lineSegments as { segmentClass?: string; isMapped?: boolean }[] | null;
+    if (!segments) continue;
+
+    for (const seg of segments) {
+      if (seg.segmentClass === 'continuation' || seg.segmentClass === 'addition') {
+        // Find matching source lines for this page and mark them
+        const pageLines = sourceLines.filter(l => l.pageNumber === page.pageNumber);
+        for (const pl of pageLines) {
+          if (!pl.specialAreaHint) {
+            // Only override if not already set from structured metadata
+          }
+        }
+      }
+    }
+  }
+
+  // Step 2: Identify protected blocks
+  const protectedRanges = identifyProtectedBlocks(sourceLines);
+
+  // Step 3: AI boundary classification for unprotected body text
+  const unprotectedBoundaries = getUnprotectedBoundaries(sourceLines, protectedRanges);
+  let aiDecisions: BoundaryDecision[] = [];
+
+  if (unprotectedBoundaries.length > 0) {
+    try {
+      aiDecisions = await classifyBoundaries(unprotectedBoundaries, letterId);
+    } catch (err) {
+      log.warn({ letterId, err }, 'AI boundary classification failed — using heuristic fallback');
+      // Heuristic fallback is handled by assembleReaderBlocks via inferDefaultDecision
+    }
+  }
+
+  // Step 4: Assemble blocks
+  const readerBlocks = assembleReaderBlocks(sourceLines, protectedRanges, aiDecisions);
+
+  // Save to database
+  await db.update(letters).set({
+    readerBlocks: readerBlocks as unknown as Record<string, unknown>[],
+    readerDecisions: aiDecisions as unknown as Record<string, unknown>[],
+    updatedAt: new Date(),
+  }).where(eq(letters.id, letterId));
+
+  log.info(
+    { letterId, blockCount: readerBlocks.length, decisionCount: aiDecisions.length },
+    'Reader blocks derived and saved',
+  );
+
+  return readerBlocks;
+}
+
+/**
+ * Extract unprotected boundary pairs for AI classification.
+ * Returns pairs of consecutive lines where the boundary is ambiguous.
+ */
+function getUnprotectedBoundaries(
+  lines: ReaderSourceLine[],
+  protectedRanges: ProtectedRange[],
+): ReaderSourceLine[] {
+  const protectedIndices = new Set<number>();
+  for (const range of protectedRanges) {
+    for (let i = range.startIdx; i <= range.endIdx; i++) {
+      protectedIndices.add(i);
+    }
+  }
+
+  // Return all non-blank, non-protected lines (the AI classifies boundaries between them)
+  return lines.filter((line, idx) =>
+    !line.isBlank && !protectedIndices.has(idx),
+  );
+}

--- a/backend/src/types/readerView.ts
+++ b/backend/src/types/readerView.ts
@@ -1,0 +1,60 @@
+/* ── Reader View V2 types ────────────────────────────────── */
+
+/** Segment classification (admin-assigned per segment) */
+export type SegmentClass = 'body' | 'continuation' | 'addition' | 'ignore';
+
+export interface SegmentClassification {
+  class: SegmentClass;
+  isMapped: boolean;
+  mappedLineIds?: string[];
+}
+
+/** Per-boundary decision between consecutive source lines */
+export type ReaderDecision =
+  | 'join_with_space'
+  | 'join_remove_hyphen'
+  | 'new_paragraph'
+  | 'keep_separate_block'
+  | 'continues_special_area'
+  | 'uncertain';
+
+/** Structural block type for the reader view */
+export type ReaderBlockType =
+  | 'date'
+  | 'salutation'
+  | 'paragraph'
+  | 'closing'
+  | 'signature'
+  | 'postscript'
+  | 'continuation'
+  | 'addition'
+  | 'address';
+
+/** Normalized line produced from the canonical transcript */
+export interface ReaderSourceLine {
+  id: string;
+  pageNumber: number;
+  order: number;
+  text: string;
+  isBlank: boolean;
+  pageBreakBefore: boolean;
+  pageBreakAfter: boolean;
+  indentHint: 'none' | 'small' | 'large';
+  roleHint?: ReaderBlockType | 'body';
+  specialAreaHint?: 'continuation' | 'addition';
+}
+
+/** Assembled block for rendering in the public reader view */
+export interface ReaderBlock {
+  id: string;
+  type: ReaderBlockType;
+  lineIds: string[];
+  text: string;
+  alignment?: 'left' | 'indented' | 'right-shifted' | 'aside';
+}
+
+/** Boundary decision record (stored for audit) */
+export interface BoundaryDecision {
+  afterLineId: string;
+  decision: ReaderDecision;
+}

--- a/frontend/src/api/admin/letters.ts
+++ b/frontend/src/api/admin/letters.ts
@@ -1,5 +1,6 @@
 import { apiGet, apiPost, apiPut, apiPatch } from "../client";
 import type { Letter, LineSegment, SegmentTrustState } from "../../types/Letter";
+import type { SegmentClassification } from "../../types/ReaderView";
 
 export interface UpdateLetterData {
   transcriptionText?: string;
@@ -132,4 +133,12 @@ export async function updatePageSegmentTrust(pageId: string, trustState: Segment
 /** Update segment trust state for all pages of a letter. */
 export async function updateLetterSegmentTrust(letterId: string, trustState: SegmentTrustState): Promise<void> {
   await apiPatch(`/admin/letters/${letterId}/segment-trust`, { trustState });
+}
+
+/** Save segment classifications for a page. */
+export async function savePageSegmentClassifications(
+  pageId: string,
+  classifications: Record<number, SegmentClassification>,
+): Promise<void> {
+  await apiPatch(`/admin/letters/pages/${pageId}/segment-classifications`, { classifications });
 }

--- a/frontend/src/api/admin/letters.ts
+++ b/frontend/src/api/admin/letters.ts
@@ -142,3 +142,11 @@ export async function savePageSegmentClassifications(
 ): Promise<void> {
   await apiPatch(`/admin/letters/pages/${pageId}/segment-classifications`, { classifications });
 }
+
+/** Derive reader blocks for a letter (Reader View V2). */
+export async function deriveReaderBlocks(letterId: string): Promise<import('../../types/ReaderView').ReaderBlock[]> {
+  const result = await apiPost<{ ok: boolean; blocks: import('../../types/ReaderView').ReaderBlock[] }>(
+    `/admin/letters/${letterId}/derive-reader-blocks`,
+  );
+  return result.blocks;
+}

--- a/frontend/src/components/LineReviewMode/LineReviewMode.css
+++ b/frontend/src/components/LineReviewMode/LineReviewMode.css
@@ -1022,6 +1022,15 @@
   cursor: default;
 }
 
+.seg-editor-action-btn.skip-to-text {
+  color: rgba(96, 165, 250, 0.9);
+  border-color: rgba(96, 165, 250, 0.3);
+}
+.seg-editor-action-btn.skip-to-text:hover {
+  color: rgba(96, 165, 250, 1);
+  background: rgba(96, 165, 250, 0.12);
+}
+
 /* Segment classification buttons */
 .segment-class-btn {
   text-transform: capitalize;

--- a/frontend/src/components/LineReviewMode/LineReviewMode.tsx
+++ b/frontend/src/components/LineReviewMode/LineReviewMode.tsx
@@ -8,7 +8,7 @@ import {
   useImperativeHandle,
 } from 'react';
 import { getErrorMessage, getImageUrl } from '../../api/client';
-import { getPageLineSegments, savePageLineSegments, updatePageSegmentTrust } from '../../api/admin/letters';
+import { getPageLineSegments, savePageLineSegments, savePageSegmentClassifications, updatePageSegmentTrust } from '../../api/admin/letters';
 import type { Letter, LineSegment, LineSegmentWord, SpecialArea } from '../../types/Letter';
 import { useSegmentEditor } from '../../hooks/useSegmentEditor';
 import SegmentEditorOverlay from './SegmentEditorOverlay';
@@ -809,8 +809,12 @@ const LineReviewMode = forwardRef<LineReviewModeHandle, LineReviewModeProps>(fun
     const pageId = letterPages[currentLetterPageIndex]?.id;
     if (!pageId) return;
     const segments = segmentEditor.getSegmentsForSave();
+    const classifications = segmentEditor.getClassificationsForSave();
     try {
       await savePageLineSegments(pageId, segments);
+      if (classifications) {
+        await savePageSegmentClassifications(pageId, classifications);
+      }
       // Update lastSourceRef BEFORE mutating the map so the sync effect
       // doesn't treat our own save as an external change and reset selection.
       const nextKraken = { ...krakenSegmentsMap, [currentLetterPageIndex]: segments };
@@ -1938,6 +1942,17 @@ const LineReviewMode = forwardRef<LineReviewModeHandle, LineReviewModeProps>(fun
           >
             Discard
           </button>
+          {fullViewport && (
+            <button
+              className="seg-editor-action-btn skip-to-text"
+              onClick={async () => {
+                await handleExitSegmentEditMode();
+              }}
+              title="Skip segment review and go to transcript editing"
+            >
+              Skip to Text
+            </button>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/ReaderBlockRenderer.css
+++ b/frontend/src/components/ReaderBlockRenderer.css
@@ -1,0 +1,115 @@
+/* ── Reader Block Renderer ─────────────────────────────────── */
+/* Matches the existing .transcript-text styling from LetterDetailPage */
+
+.reader-blocks {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.08rem;
+  line-height: 1.85;
+  color: var(--text);
+}
+
+.reader-block {
+  margin: 0 0 0.2em;
+  word-break: break-word;
+}
+
+/* Paragraphs get spacing between them */
+.reader-block-paragraph {
+  text-indent: 0;
+  margin-bottom: 1em;
+}
+.reader-block-paragraph + .reader-block-paragraph {
+  margin-top: 0;
+}
+
+/* Date — typically right-shifted or at top */
+.reader-block-date {
+  font-style: italic;
+  margin-bottom: 1.2em;
+}
+
+/* Salutation */
+.reader-block-salutation {
+  margin-bottom: 0.8em;
+}
+
+/* Closing — typically indented or right-shifted */
+.reader-block-closing {
+  margin-top: 1.2em;
+  margin-bottom: 0.3em;
+}
+
+/* Signature — follows closing */
+.reader-block-signature {
+  margin-bottom: 1em;
+}
+
+/* Postscript */
+.reader-block-postscript {
+  margin-top: 1.5em;
+  font-size: 0.95em;
+  border-left: 2px solid var(--border, rgba(0, 0, 0, 0.1));
+  padding-left: 1em;
+}
+
+/* Continuation — text that continues from a different area */
+.reader-block-continuation {
+  font-size: 0.95em;
+  opacity: 0.85;
+  border-left: 2px solid var(--border, rgba(0, 0, 0, 0.1));
+  padding-left: 1em;
+  margin-top: 1em;
+}
+
+/* Addition — marginalia, side notes */
+.reader-block-addition {
+  font-size: 0.92em;
+  font-style: italic;
+  border-left: 2px dashed var(--border, rgba(0, 0, 0, 0.15));
+  padding-left: 1em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  opacity: 0.8;
+}
+
+/* Address */
+.reader-block-address {
+  margin-bottom: 1em;
+  white-space: pre-line;
+}
+
+/* ── Alignment variants ─────────────────────────────────────── */
+
+.reader-align-indented {
+  padding-left: 2em;
+}
+
+.reader-align-right-shifted {
+  text-align: right;
+  padding-right: 1em;
+}
+
+.reader-align-aside {
+  margin-left: 2em;
+}
+
+/* ── Mobile adjustments ─────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .reader-blocks {
+    font-size: 1rem;
+    line-height: 1.75;
+  }
+
+  .reader-align-indented {
+    padding-left: 1.2em;
+  }
+
+  .reader-align-right-shifted {
+    padding-right: 0.5em;
+  }
+
+  .reader-align-aside {
+    margin-left: 1em;
+  }
+}

--- a/frontend/src/components/ReaderBlockRenderer.tsx
+++ b/frontend/src/components/ReaderBlockRenderer.tsx
@@ -1,0 +1,98 @@
+/**
+ * ReaderBlockRenderer — renders derived ReaderBlock[] for the public reader view.
+ *
+ * Each block gets a semantic CSS class based on its type. Body paragraphs
+ * render as <p>, structural elements (date, salutation, etc.) as styled <div>.
+ */
+
+import type { ReaderBlock } from '../types/ReaderView';
+import './ReaderBlockRenderer.css';
+
+interface ReaderBlockRendererProps {
+  blocks: ReaderBlock[];
+  className?: string;
+}
+
+export default function ReaderBlockRenderer({ blocks, className }: ReaderBlockRendererProps) {
+  return (
+    <div className={`reader-blocks${className ? ` ${className}` : ''}`}>
+      {blocks.map((block) => {
+        const alignClass = block.alignment && block.alignment !== 'left'
+          ? ` reader-align-${block.alignment}`
+          : '';
+
+        switch (block.type) {
+          case 'paragraph':
+            return (
+              <p key={block.id} className={`reader-block reader-block-paragraph${alignClass}`}>
+                {block.text}
+              </p>
+            );
+
+          case 'date':
+            return (
+              <div key={block.id} className={`reader-block reader-block-date${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          case 'salutation':
+            return (
+              <div key={block.id} className={`reader-block reader-block-salutation${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          case 'closing':
+            return (
+              <div key={block.id} className={`reader-block reader-block-closing${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          case 'signature':
+            return (
+              <div key={block.id} className={`reader-block reader-block-signature${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          case 'postscript':
+            return (
+              <div key={block.id} className={`reader-block reader-block-postscript${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          case 'continuation':
+            return (
+              <div key={block.id} className={`reader-block reader-block-continuation${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          case 'addition':
+            return (
+              <aside key={block.id} className={`reader-block reader-block-addition${alignClass}`}>
+                {block.text}
+              </aside>
+            );
+
+          case 'address':
+            return (
+              <div key={block.id} className={`reader-block reader-block-address${alignClass}`}>
+                {block.text}
+              </div>
+            );
+
+          default:
+            return (
+              <p key={block.id} className={`reader-block${alignClass}`}>
+                {block.text}
+              </p>
+            );
+        }
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSegmentEditor.ts
+++ b/frontend/src/hooks/useSegmentEditor.ts
@@ -458,6 +458,8 @@ export interface UseSegmentEditorReturn {
   resetFromSource: (segments: LineSegment[], options?: ResetFromSourceOptions) => void;
   /** Returns cleaned segments ready for API persistence. */
   getSegmentsForSave: () => LineSegment[];
+  /** Returns segment classifications extracted from current segments, keyed by segment index. */
+  getClassificationsForSave: () => Record<number, { class: string; isMapped: boolean; mappedLineIds?: string[] }> | null;
   /** Mark state as saved without clearing in-session undo history. */
   markSaved: () => void;
   /** Clear edit-session history and dirty state. */
@@ -1059,6 +1061,22 @@ export function useSegmentEditor(
     return toLineSegments(editedSegments);
   }, [editedSegments]);
 
+  const getClassificationsForSave = useCallback(() => {
+    const saved = toLineSegments(editedSegments);
+    const hasAny = saved.some(s => s.segmentClass && s.segmentClass !== 'body');
+    if (!hasAny) return null;
+    const out: Record<number, { class: string; isMapped: boolean; mappedLineIds?: string[] }> = {};
+    for (const s of saved) {
+      if (s.segmentClass) {
+        out[s.line] = {
+          class: s.segmentClass,
+          isMapped: s.isMapped ?? false,
+        };
+      }
+    }
+    return out;
+  }, [editedSegments]);
+
   const markSaved = useCallback(() => {
     setIsDirty(false);
   }, []);
@@ -1100,6 +1118,7 @@ export function useSegmentEditor(
     canRedo,
     resetFromSource,
     getSegmentsForSave,
+    getClassificationsForSave,
     markSaved,
     clearSessionHistory,
     moveVertex,

--- a/frontend/src/pages/LetterDetailPage.css
+++ b/frontend/src/pages/LetterDetailPage.css
@@ -316,6 +316,7 @@
   overflow: visible;
   border-left: 1px solid transparent;
   padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .letter-transcript-section.transcript-original-mode {
@@ -1063,6 +1064,11 @@
       1rem [wide-end full-end];
   }
 
+  .letter-transcript-section.transcript-original-mode {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
   .letter-hero-section {
     padding: 1.8rem 0 1.3rem;
   }
@@ -1143,6 +1149,11 @@
       [full-start wide-start] 1.25rem
       [content-start] 1fr [content-end]
       1.25rem [wide-end full-end];
+  }
+
+  .letter-transcript-section.transcript-original-mode {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
   }
 
   .letter-hero-section {

--- a/frontend/src/pages/LetterDetailPage.tsx
+++ b/frontend/src/pages/LetterDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   shouldShowPhotoDescriptionWorkflow,
 } from "../utils/letterContent";
 import { reflowTranscript, renderTranscriptLines, computeReferenceWidth } from "../utils/transcriptRendering";
+import ReaderBlockRenderer from "../components/ReaderBlockRenderer";
 import HeaderDock from "../components/Header/HeaderDock";
 import HeaderScrubber from "../components/HeaderScrubber/HeaderScrubber";
 import useLetterScrubber from "../components/LetterHeaderDock/useLetterScrubber";
@@ -514,7 +515,42 @@ export default function LetterDetailPage() {
               </button>
             </div>
 
-            {transcriptMode === "reading" && letter.readingText ? (
+            {transcriptMode === "reading" && letter.readerBlocks && letter.readerBlocks.length > 0 ? (
+              /* ── Reader View V2 — derived block-based rendering ── */
+              <div className="transcript-pages-combined">
+                <div className="transcript-page-region">
+                  <div className="transcript-page-body">
+                    {letterTypeImages.length > 0 && letterTypeImages.map((pageImage, idx) => {
+                      const side = idx % 2 === 0 ? "left" : "right";
+                      return (
+                        <button
+                          key={pageImage.id}
+                          type="button"
+                          className={`page-thumb page-thumb-${side}${transcriptVerifClass}`}
+                          onClick={() => openViewer(Math.max(0, allImages.indexOf(pageImage)))}
+                          aria-label={`View page ${pageImage.pageNumber ?? idx + 1}`}
+                          style={idx > 0 ? { top: `${idx * 14}rem` } : undefined}
+                        >
+                          <span className="page-thumb-inner">
+                            <img
+                              src={getImageUrl(pageImage.imageUrl, { width: 300 })}
+                              alt={`Page ${pageImage.pageNumber ?? idx + 1}`}
+                              className="page-thumb-img"
+                              loading="lazy"
+                            />
+                            <span className="page-thumb-label">Page {pageImage.pageNumber ?? idx + 1}</span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                    <ReaderBlockRenderer
+                      blocks={letter.readerBlocks}
+                      className={shortLineClass.trim() || undefined}
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : transcriptMode === "reading" && letter.readingText ? (
               /* ── Saved reading text — render exactly as admin set it ── */
               <div className="transcript-pages-combined">
                 <div className="transcript-page-region">

--- a/frontend/src/pages/admin/LetterReviewPage.tsx
+++ b/frontend/src/pages/admin/LetterReviewPage.tsx
@@ -183,7 +183,6 @@ export default function LetterReviewPage() {
   );
   const [reviewMode, setReviewMode] = useState(false);
   const [segmentFirstMode, setSegmentFirstMode] = useState(false);
-  const segmentFirstTriggeredRef = useRef(false);
   const [debugMode, setDebugMode] = useState(false);
   const [viewerPageIndex, setViewerPageIndex] = useState(0);
   // Mapping mode: selected transcript text to map to a segment
@@ -305,26 +304,6 @@ export default function LetterReviewPage() {
       fetchLetter();
     }
   }, [applyLetterMetadata, letterId, navigate]);
-
-  // Segment-first entry: auto-enter full-viewport segment review when pages
-  // have unverified segments with data. Only triggers once per letter visit.
-  useEffect(() => {
-    if (!letter || segmentFirstTriggeredRef.current) return;
-    segmentFirstTriggeredRef.current = true;
-
-    const letterImages = letter.images.filter((img) => img.type === 'letter');
-    const hasUnverifiedSegments = letterImages.some(
-      (img) =>
-        img.segmentTrustState !== 'trusted' &&
-        img.lineSegments &&
-        img.lineSegments.length > 0,
-    );
-
-    if (hasUnverifiedSegments) {
-      setReviewMode(true);
-      setSegmentFirstMode(true);
-    }
-  }, [letter]);
 
   useEffect(() => {
     if (!letter || !routeLocation.hash) return;

--- a/frontend/src/types/Letter.ts
+++ b/frontend/src/types/Letter.ts
@@ -323,6 +323,8 @@ export interface Letter {
   aiNotes?: string;
   // Reading view text (independent spacing from raw transcript)
   readingText?: string;
+  // Reader View V2: derived block-based rendering
+  readerBlocks?: import('./ReaderView').ReaderBlock[];
   // Entity extraction (Prompt 2)
   entityExtractionStatus?: string;
   entityExtractionJson?: unknown;

--- a/frontend/src/types/ReaderView.ts
+++ b/frontend/src/types/ReaderView.ts
@@ -1,0 +1,60 @@
+/* ── Reader View V2 types ────────────────────────────────── */
+
+/** Segment classification (admin-assigned per segment) */
+export type SegmentClass = 'body' | 'continuation' | 'addition' | 'ignore';
+
+export interface SegmentClassification {
+  class: SegmentClass;
+  isMapped: boolean;
+  mappedLineIds?: string[];
+}
+
+/** Per-boundary decision between consecutive source lines */
+export type ReaderDecision =
+  | 'join_with_space'
+  | 'join_remove_hyphen'
+  | 'new_paragraph'
+  | 'keep_separate_block'
+  | 'continues_special_area'
+  | 'uncertain';
+
+/** Structural block type for the reader view */
+export type ReaderBlockType =
+  | 'date'
+  | 'salutation'
+  | 'paragraph'
+  | 'closing'
+  | 'signature'
+  | 'postscript'
+  | 'continuation'
+  | 'addition'
+  | 'address';
+
+/** Normalized line produced from the canonical transcript */
+export interface ReaderSourceLine {
+  id: string;
+  pageNumber: number;
+  order: number;
+  text: string;
+  isBlank: boolean;
+  pageBreakBefore: boolean;
+  pageBreakAfter: boolean;
+  indentHint: 'none' | 'small' | 'large';
+  roleHint?: ReaderBlockType | 'body';
+  specialAreaHint?: 'continuation' | 'addition';
+}
+
+/** Assembled block for rendering in the public reader view */
+export interface ReaderBlock {
+  id: string;
+  type: ReaderBlockType;
+  lineIds: string[];
+  text: string;
+  alignment?: 'left' | 'indented' | 'right-shifted' | 'aside';
+}
+
+/** Boundary decision record (stored for audit) */
+export interface BoundaryDecision {
+  afterLineId: string;
+  decision: ReaderDecision;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,8 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5184,
-    strictPort: true,
+    port: 5174,
     // Force browser to always check for updates in development
     headers: {
       'Cache-Control': 'no-store',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,8 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5174,
+    port: 5184,
+    strictPort: true,
     // Force browser to always check for updates in development
     headers: {
       'Cache-Control': 'no-store',


### PR DESCRIPTION
## Summary

- **Fix asymmetric mobile padding** on transcript section — adds matching `padding-right` so text no longer runs into the right screen edge on mobile
- **Reader View V2 pipeline** — replaces ad-hoc `readingText` with a derived rendering system:
  - Source line normalization from canonical transcript text + structured page metadata
  - Deterministic protected block detection (date, salutation, closing, signature, postscript, address)
  - AI boundary classifier (gpt-5.4-mini, tool calling) with heuristic fallback for joining/splitting body text
  - Block-based public renderer with semantic CSS classes and type-specific styling
- **Segment classification persistence** — wires admin segment editor classifications to new `segment_classifications` column for pipeline consumption
- **New migration** (`0045_reader_view_v2`) adds `reader_blocks`, `reader_decisions` on `letters` and `segment_classifications` on `letter_pages`
- **Fallback chain preserved**: `readerBlocks` → `readingText` → `readingSegments` → raw reflow — no breaking changes to existing letters

## New files

- `backend/src/services/letter/readerDerivation.ts` — core 4-step derivation pipeline
- `backend/src/ai/openai/boundaryClassifier.ts` — narrow AI structural classifier
- `backend/src/types/readerView.ts` + `frontend/src/types/ReaderView.ts` — shared types
- `frontend/src/components/ReaderBlockRenderer.tsx` + `.css` — block-based renderer

## Test plan

- [ ] Verify symmetric transcript padding on mobile viewports (320px, 375px, 768px)
- [ ] Run migration: `npm run drizzle:migrate` — verify new columns exist
- [ ] Test segment classification save via admin line review mode
- [ ] Trigger `POST /admin/letters/:id/derive-reader-blocks` on a multi-page letter
- [ ] Verify block renderer displays correctly on public LetterDetailPage
- [ ] Verify fallback: letter without `readerBlocks` still renders via `readingText`/reflow
- [ ] All existing tests pass (`npm test` in both frontend and backend)

Closes #22.