### PR TITLE
Add ./dev universal start script

### DIFF
--- a/dev
+++ b/dev
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# dev — start dev servers. Works identically from main repo or any worktree.
+#
+# Usage:
+#   ./dev                 # start backend + frontend
+#   ./dev backend         # start backend only
+#   ./dev frontend        # start frontend only
+#   ./dev --lan           # start both with LAN access (phone testing)
+#   ./dev frontend --lan  # start frontend only with LAN
+#
+# In a worktree, ports are auto-assigned and won't conflict with main or
+# other worktrees. Run setup-worktree.sh first if this is a fresh worktree
+# (this script will remind you).
+#
+# In the main repo, uses default ports (backend 3002, frontend 5174).
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+MAIN_ROOT=$(git worktree list --porcelain | awk '/^worktree / { print $2; exit }')
+IS_WORKTREE=false
+[[ "$REPO_ROOT" != "$MAIN_ROOT" ]] && IS_WORKTREE=true
+
+# ── parse args ─────────────────────────────────────────────────────────────
+TARGET=""  # "", "backend", or "frontend"
+LAN=false
+
+for arg in "$@"; do
+  case $arg in
+    backend)  TARGET="backend" ;;
+    frontend) TARGET="frontend" ;;
+    --lan)    LAN=true ;;
+    *)        echo "usage: ./dev [backend|frontend] [--lan]"; exit 1 ;;
+  esac
+done
+
+# ── resolve ports ──────────────────────────────────────────────────────────
+BACKEND_PORT=3002
+FRONTEND_PORT=5174
+
+if $IS_WORKTREE; then
+  # Worktree: read ports from env files written by setup-worktree.sh
+  if [[ ! -f "$REPO_ROOT/backend/.env" || ! -f "$REPO_ROOT/frontend/.env.local" ]]; then
+    echo "This worktree hasn't been set up yet. Run:"
+    echo "  ./scripts/setup-worktree.sh"
+    exit 1
+  fi
+  BACKEND_PORT=$(grep -E "^PORT=" "$REPO_ROOT/backend/.env" | head -1 | cut -d= -f2 | tr -d '[:space:]')
+  FRONTEND_PORT=$(grep -E "^VITE_SITE_URL=" "$REPO_ROOT/frontend/.env.local" | head -1 | sed -E 's|.*:([0-9]+).*|\1|')
+
+  if [[ -z "$BACKEND_PORT" || -z "$FRONTEND_PORT" ]]; then
+    echo "Could not read ports from env files. Re-run:"
+    echo "  ./scripts/setup-worktree.sh --force"
+    exit 1
+  fi
+fi
+
+# ── LAN IP ─────────────────────────────────────────────────────────────────
+LAN_IP=""
+if $LAN; then
+  # macOS: grab IPv4 from en0/en1, fallback to routing table trick
+  LAN_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)
+  if [[ -z "$LAN_IP" ]]; then
+    LAN_IP=$(python3 -c "
+import socket; s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try: s.connect(('10.255.255.255', 1)); print(s.getsockname()[0])
+except: print('')
+finally: s.close()
+" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$LAN_IP" ]]; then
+    echo "warning: could not detect LAN IP, falling back to localhost only"
+    LAN=false
+  fi
+fi
+
+# ── banner ─────────────────────────────────────────────────────────────────
+echo ""
+if $IS_WORKTREE; then
+  WT_NAME=$(basename "$REPO_ROOT")
+  echo "  ┌─────────────────────────────────────────────────┐"
+  echo "  │  worktree: $WT_NAME"
+else
+  echo "  ┌─────────────────────────────────────────────────┐"
+  echo "  │  main repo"
+fi
+echo "  │"
+if [[ -z "$TARGET" || "$TARGET" == "backend" ]]; then
+  echo "  │  backend:  http://localhost:$BACKEND_PORT"
+fi
+if [[ -z "$TARGET" || "$TARGET" == "frontend" ]]; then
+  echo "  │  frontend: http://localhost:$FRONTEND_PORT"
+  if $LAN; then
+    echo "  │  phone:    http://$LAN_IP:$FRONTEND_PORT"
+  fi
+fi
+echo "  └─────────────────────────────────────────────────┘"
+echo ""
+
+# ── start servers ──────────────────────────────────────────────────────────
+PIDS=()
+
+cleanup() {
+  echo ""
+  echo "shutting down..."
+  for pid in "${PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+start_backend() {
+  cd "$REPO_ROOT/backend"
+  # Explicitly pass PORT and STORAGE_DIR to override anything direnv exported
+  # at the shell level — process.env beats dotenv/config, so a stale direnv
+  # PORT=3002 would otherwise mask the worktree's backend/.env PORT.
+  PORT="$BACKEND_PORT" STORAGE_DIR="./storage" npm run dev &
+  PIDS+=($!)
+  cd "$REPO_ROOT"
+}
+
+start_frontend() {
+  cd "$REPO_ROOT/frontend"
+  if $LAN; then
+    npx vite --port "$FRONTEND_PORT" --strictPort --host 0.0.0.0 &
+  else
+    npx vite --port "$FRONTEND_PORT" --strictPort &
+  fi
+  PIDS+=($!)
+  cd "$REPO_ROOT"
+}
+
+case "$TARGET" in
+  backend)  start_backend ;;
+  frontend) start_frontend ;;
+  *)        start_backend; start_frontend ;;
+esac
+
+# Wait for any child to exit
+wait

--- a/dev
+++ b/dev
@@ -46,8 +46,10 @@ if $IS_WORKTREE; then
     echo "  ./scripts/setup-worktree.sh"
     exit 1
   fi
-  BACKEND_PORT=$(grep -E "^PORT=" "$REPO_ROOT/backend/.env" | head -1 | cut -d= -f2 | tr -d '[:space:]')
-  FRONTEND_PORT=$(grep -E "^VITE_SITE_URL=" "$REPO_ROOT/frontend/.env.local" | head -1 | sed -E 's|.*:([0-9]+).*|\1|')
+  # `|| true` so a missing/malformed line doesn't trip pipefail and skip the
+  # friendly error below.
+  BACKEND_PORT=$(grep -E "^PORT=" "$REPO_ROOT/backend/.env" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]' || true)
+  FRONTEND_PORT=$(grep -E "^VITE_SITE_URL=" "$REPO_ROOT/frontend/.env.local" 2>/dev/null | head -1 | sed -E 's|.*:([0-9]+).*|\1|' || true)
 
   if [[ -z "$BACKEND_PORT" || -z "$FRONTEND_PORT" ]]; then
     echo "Could not read ports from env files. Re-run:"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -154,17 +154,9 @@ cat > "$LAUNCH" <<EOF
   "configurations": [
     {
       "name": "frontend",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--", "--port", "$FRONTEND_PORT", "--strictPort"],
-      "cwd": "frontend",
+      "runtimeExecutable": "./dev",
+      "runtimeArgs": [],
       "port": $FRONTEND_PORT
-    },
-    {
-      "name": "backend",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
-      "cwd": "backend",
-      "port": $BACKEND_PORT
     }
   ]
 }

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -155,8 +155,14 @@ cat > "$LAUNCH" <<EOF
     {
       "name": "frontend",
       "runtimeExecutable": "./dev",
-      "runtimeArgs": [],
+      "runtimeArgs": ["frontend"],
       "port": $FRONTEND_PORT
+    },
+    {
+      "name": "backend",
+      "runtimeExecutable": "./dev",
+      "runtimeArgs": ["backend"],
+      "port": $BACKEND_PORT
     }
   ]
 }


### PR DESCRIPTION
## Summary

Single command to start dev servers — works identically from the main repo or any worktree.

```
./dev                # backend + frontend
./dev backend        # backend only
./dev frontend       # frontend only
./dev --lan          # bind frontend to 0.0.0.0 for phone testing
```

## How it resolves ports

- **Main repo**: defaults (backend 3002, frontend 5174).
- **Worktree**: reads `PORT` from `backend/.env` and the frontend port from `VITE_SITE_URL` in `frontend/.env.local` — both written by `scripts/setup-worktree.sh`. Errors out with a clear message if those files don't exist.

## Notes

- **Override direnv.** The script explicitly passes `PORT="$BACKEND_PORT"` to `npm run dev` because `dotenv/config` doesn't override existing `process.env`. Without this, a shell-level `PORT=3002` from direnv silently masks the worktree's port and the backend tries to bind to 3002.
- **Independent runs.** `./dev backend` and `./dev frontend` in separate terminals still talk to each other — they read the same env files.
- **`setup-worktree.sh`** now writes a simpler `launch.json` with a single `frontend` entry pointing at `./dev` (no `cwd`), so the Claude Code preview button launches both servers via one entry.
- `dev` script lives at the repo root and is `chmod +x`.

## Test plan

- [ ] `./dev` from main repo — both servers come up on 3002 / 5174
- [ ] `./dev` from a fresh worktree (after `setup-worktree.sh`) — both come up on the assigned ports
- [ ] `./dev backend` only — backend up, frontend not
- [ ] `./dev frontend` only — frontend up, backend not
- [ ] `./dev --lan` — frontend reachable from phone on same Wi-Fi
- [ ] Ctrl-C cleanly shuts down both child processes