### PR TITLE
fix(upload): deduplicate renamed upload content

### DIFF
--- a/backend/src/routes/admin/__tests__/uploads.integration.test.ts
+++ b/backend/src/routes/admin/__tests__/uploads.integration.test.ts
@@ -4,7 +4,7 @@ import { invokeRouter } from '../../../test/express-test-utils.js';
 const {
   dbSelectMock,
   ensureBackgroundWorkerForQueuedProcessingMock,
-  findPageByChecksumMock,
+  findPagesByChecksumsMock,
   findObservedPageSourcesByIdentityMock,
   unlinkMock,
   notifyMock,
@@ -13,7 +13,7 @@ const {
 } = vi.hoisted(() => ({
   dbSelectMock: vi.fn(),
   ensureBackgroundWorkerForQueuedProcessingMock: vi.fn(),
-  findPageByChecksumMock: vi.fn(),
+  findPagesByChecksumsMock: vi.fn(),
   findObservedPageSourcesByIdentityMock: vi.fn(),
   unlinkMock: vi.fn(),
   notifyMock: vi.fn(),
@@ -69,7 +69,7 @@ vi.mock('../../../services/letter-pages.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../services/letter-pages.js')>();
   return {
     ...actual,
-    findPageByChecksum: findPageByChecksumMock,
+    findPagesByChecksums: findPagesByChecksumsMock,
     findObservedPageSourcesByIdentity: findObservedPageSourcesByIdentityMock,
   };
 });
@@ -104,7 +104,7 @@ describe('admin uploads route integration', () => {
       outcome: 'created',
       changed: true,
     });
-    findPageByChecksumMock.mockResolvedValue(undefined);
+    findPagesByChecksumsMock.mockResolvedValue([]);
     findObservedPageSourcesByIdentityMock.mockResolvedValue(new Map());
   });
 
@@ -159,9 +159,11 @@ describe('admin uploads route integration', () => {
   });
 
   it('checks optional file hashes for content duplicates', async () => {
-    findPageByChecksumMock.mockResolvedValueOnce({
+    const checksum = 'a'.repeat(64);
+    findPagesByChecksumsMock.mockResolvedValueOnce([{
       id: 'page-existing-content',
-    });
+      checksumSha256: checksum,
+    }]);
 
     const response = await invokeRouter(uploadsRouter, {
       method: 'POST',
@@ -173,7 +175,7 @@ describe('admin uploads route integration', () => {
           '003-19320706-L01-02.jpg',
         ],
         hashes: {
-          '003-19320706-L01-01.jpg': 'checksum-one',
+          '003-19320706-L01-01.jpg': checksum.toUpperCase(),
         },
       },
       headers: { 'content-type': 'application/json' },
@@ -185,8 +187,84 @@ describe('admin uploads route integration', () => {
         '003-19320706-L01-01.jpg': true,
       },
     });
-    expect(findPageByChecksumMock).toHaveBeenCalledWith('checksum-one');
-    expect(findPageByChecksumMock).toHaveBeenCalledTimes(1);
+    expect(findPagesByChecksumsMock).toHaveBeenCalledWith([checksum]);
+    expect(findPagesByChecksumsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed hashes before querying duplicate state', async () => {
+    const response = await invokeRouter(uploadsRouter, {
+      method: 'POST',
+      url: '/uploads/check-duplicates',
+      path: '/uploads/check-duplicates',
+      body: {
+        filenames: ['003-19320706-L01-01.jpg'],
+        hashes: {
+          '003-19320706-L01-01.jpg': 'not-a-sha-256',
+        },
+      },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toMatchObject({
+      error: 'Invalid duplicate check request',
+    });
+    expect(findObservedPageSourcesByIdentityMock).not.toHaveBeenCalled();
+    expect(findPagesByChecksumsMock).not.toHaveBeenCalled();
+  });
+
+  it('caps duplicate checks at the upload batch limit', async () => {
+    const response = await invokeRouter(uploadsRouter, {
+      method: 'POST',
+      url: '/uploads/check-duplicates',
+      path: '/uploads/check-duplicates',
+      body: {
+        filenames: Array.from(
+          { length: 501 },
+          () => '003-19320706-L01-01.jpg',
+        ),
+      },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toMatchObject({
+      error: 'Invalid duplicate check request',
+    });
+    expect(findObservedPageSourcesByIdentityMock).not.toHaveBeenCalled();
+    expect(findPagesByChecksumsMock).not.toHaveBeenCalled();
+  });
+
+  it('batches repeated checksum lookups into one query', async () => {
+    const checksum = 'b'.repeat(64);
+    findPagesByChecksumsMock.mockResolvedValueOnce([]);
+
+    const response = await invokeRouter(uploadsRouter, {
+      method: 'POST',
+      url: '/uploads/check-duplicates',
+      path: '/uploads/check-duplicates',
+      body: {
+        filenames: [
+          '003-19320706-L01-01.jpg',
+          '003-19320706-L01-02.jpg',
+        ],
+        hashes: {
+          '003-19320706-L01-01.jpg': checksum,
+          '003-19320706-L01-02.jpg': checksum,
+        },
+      },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(findPagesByChecksumsMock).toHaveBeenCalledOnce();
+    expect(findPagesByChecksumsMock).toHaveBeenCalledWith([checksum]);
+    expect(response.body).toMatchObject({
+      contentDuplicates: {
+        '003-19320706-L01-01.jpg': false,
+        '003-19320706-L01-02.jpg': false,
+      },
+    });
   });
 
   it('propagates internal failures through the error handler with request id', async () => {

--- a/backend/src/routes/admin/__tests__/uploads.integration.test.ts
+++ b/backend/src/routes/admin/__tests__/uploads.integration.test.ts
@@ -4,6 +4,7 @@ import { invokeRouter } from '../../../test/express-test-utils.js';
 const {
   dbSelectMock,
   ensureBackgroundWorkerForQueuedProcessingMock,
+  findPageByChecksumMock,
   findObservedPageSourcesByIdentityMock,
   unlinkMock,
   notifyMock,
@@ -12,6 +13,7 @@ const {
 } = vi.hoisted(() => ({
   dbSelectMock: vi.fn(),
   ensureBackgroundWorkerForQueuedProcessingMock: vi.fn(),
+  findPageByChecksumMock: vi.fn(),
   findObservedPageSourcesByIdentityMock: vi.fn(),
   unlinkMock: vi.fn(),
   notifyMock: vi.fn(),
@@ -67,6 +69,7 @@ vi.mock('../../../services/letter-pages.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../services/letter-pages.js')>();
   return {
     ...actual,
+    findPageByChecksum: findPageByChecksumMock,
     findObservedPageSourcesByIdentity: findObservedPageSourcesByIdentityMock,
   };
 });
@@ -101,6 +104,7 @@ describe('admin uploads route integration', () => {
       outcome: 'created',
       changed: true,
     });
+    findPageByChecksumMock.mockResolvedValue(undefined);
     findObservedPageSourcesByIdentityMock.mockResolvedValue(new Map());
   });
 
@@ -149,8 +153,40 @@ describe('admin uploads route integration', () => {
         '003-19320706-L01-01.jpg': sourceExpectation,
         'not-valid.jpg': null,
       },
+      contentDuplicates: {},
     });
     expect(findObservedPageSourcesByIdentityMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks optional file hashes for content duplicates', async () => {
+    findPageByChecksumMock.mockResolvedValueOnce({
+      id: 'page-existing-content',
+    });
+
+    const response = await invokeRouter(uploadsRouter, {
+      method: 'POST',
+      url: '/uploads/check-duplicates',
+      path: '/uploads/check-duplicates',
+      body: {
+        filenames: [
+          '003-19320706-L01-01.jpg',
+          '003-19320706-L01-02.jpg',
+        ],
+        hashes: {
+          '003-19320706-L01-01.jpg': 'checksum-one',
+        },
+      },
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({
+      contentDuplicates: {
+        '003-19320706-L01-01.jpg': true,
+      },
+    });
+    expect(findPageByChecksumMock).toHaveBeenCalledWith('checksum-one');
+    expect(findPageByChecksumMock).toHaveBeenCalledTimes(1);
   });
 
   it('propagates internal failures through the error handler with request id', async () => {
@@ -234,6 +270,7 @@ describe('admin uploads route integration', () => {
       alreadyExists: true,
       outcome: 'unchanged',
       changed: false,
+      duplicateReason: 'duplicate_content',
     });
 
     const response = await invokeRouter(uploadsRouter, {
@@ -249,6 +286,9 @@ describe('admin uploads route integration', () => {
         changed: 0,
         unchanged: 1,
       },
+      results: [{
+        duplicateReason: 'duplicate_content',
+      }],
     });
     expect(notifyMock).not.toHaveBeenCalled();
     expect(dbSelectMock).not.toHaveBeenCalled();

--- a/backend/src/routes/admin/uploads.ts
+++ b/backend/src/routes/admin/uploads.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { processUploadedFile } from '../../services/upload.js';
 import { parseFilename } from '../../services/filename-parser.js';
 import {
+  findPageByChecksum,
   findObservedPageSourcesByIdentity,
   uploadPageIdentityKey,
   type UploadPageIdentity,
@@ -60,14 +61,21 @@ const upload = multer({
 });
 
 /**
- * POST /admin/uploads/check-duplicates - Check which filenames already exist in storage
+ * POST /admin/uploads/check-duplicates - Check which files already exist
  *
- * Accepts JSON body: { filenames: string[] }
- * Returns the duplicate flag and exact committed-source expectation per file.
+ * Accepts JSON body:
+ *   { filenames: string[], hashes?: Record<string, string> }
+ * Hashes are optional hex-encoded SHA-256 values keyed by filename.
+ *
+ * Returns filename-identity duplicates, exact committed-source expectations,
+ * and content duplicates for callers that supplied hashes.
  */
 router.post('/uploads/check-duplicates', async (req, res, next) => {
   try {
-    const { filenames } = req.body as { filenames?: string[] };
+    const { filenames, hashes } = req.body as {
+      filenames?: string[];
+      hashes?: Record<string, string>;
+    };
 
     if (!filenames || !Array.isArray(filenames)) {
       res.status(400).json({ error: 'filenames must be an array of strings' });
@@ -98,8 +106,18 @@ router.post('/uploads/check-duplicates', async (req, res, next) => {
           : null,
       ];
     }));
+    const contentDuplicates = Object.fromEntries(
+      await Promise.all(filenames.flatMap((filename) => {
+        const hash = hashes?.[filename];
+        if (!hash) return [];
+        return [findPageByChecksum(hash).then((page) => [
+          filename,
+          page !== undefined,
+        ] as const)];
+      })),
+    );
 
-    res.json({ duplicates, sourceExpectations });
+    res.json({ duplicates, sourceExpectations, contentDuplicates });
   } catch (error) {
     next(error);
   }
@@ -170,6 +188,7 @@ router.post('/uploads', upload.array('files', 500), async (req, res, next) => {
     alreadyExists: boolean;
     outcome: 'created' | 'replaced' | 'unchanged';
     changed: boolean;
+    duplicateReason?: 'duplicate_content';
   }> = [];
 
   const errors: Array<{
@@ -197,6 +216,7 @@ router.post('/uploads', upload.array('files', 500), async (req, res, next) => {
         alreadyExists: result.alreadyExists,
         outcome: result.outcome,
         changed: result.changed,
+        duplicateReason: result.duplicateReason,
       });
     } catch (error) {
       if (files.length === 1 && error instanceof SourceRevisionChangedError) {

--- a/backend/src/routes/admin/uploads.ts
+++ b/backend/src/routes/admin/uploads.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { processUploadedFile } from '../../services/upload.js';
 import { parseFilename } from '../../services/filename-parser.js';
 import {
-  findPageByChecksum,
+  findPagesByChecksums,
   findObservedPageSourcesByIdentity,
   uploadPageIdentityKey,
   type UploadPageIdentity,
@@ -33,6 +33,20 @@ const uploadSourceExpectationsSchema = z.record(
   z.string(),
   uploadSourceExpectationSchema,
 );
+const sha256Schema = z.string().regex(
+  /^[a-f0-9]{64}$/i,
+  'hashes must be hex-encoded SHA-256 values',
+).transform((hash) => hash.toLowerCase());
+const duplicateCheckRequestSchema = z.object({
+  filenames: z.array(z.string().min(1).max(255)).max(500),
+  hashes: z.record(
+    z.string().min(1).max(255),
+    sha256Schema,
+  ).refine(
+    (hashes) => Object.keys(hashes).length <= 500,
+    'hashes cannot contain more than 500 entries',
+  ).optional(),
+}).strict();
 
 async function cleanupTempFiles(files: Express.Multer.File[]): Promise<void> {
   await Promise.all(
@@ -72,15 +86,19 @@ const upload = multer({
  */
 router.post('/uploads/check-duplicates', async (req, res, next) => {
   try {
-    const { filenames, hashes } = req.body as {
-      filenames?: string[];
-      hashes?: Record<string, string>;
-    };
-
-    if (!filenames || !Array.isArray(filenames)) {
+    if (!Array.isArray(req.body?.filenames)) {
       res.status(400).json({ error: 'filenames must be an array of strings' });
       return;
     }
+    const parsedRequest = duplicateCheckRequestSchema.safeParse(req.body);
+    if (!parsedRequest.success) {
+      res.status(400).json({
+        error: 'Invalid duplicate check request',
+        details: parsedRequest.error.flatten(),
+      });
+      return;
+    }
+    const { filenames, hashes } = parsedRequest.data;
 
     const parsedByFilename = new Map<string, UploadPageIdentity>();
     for (const filename of filenames) {
@@ -106,16 +124,20 @@ router.post('/uploads/check-duplicates', async (req, res, next) => {
           : null,
       ];
     }));
-    const contentDuplicates = Object.fromEntries(
-      await Promise.all(filenames.flatMap((filename) => {
-        const hash = hashes?.[filename];
-        if (!hash) return [];
-        return [findPageByChecksum(hash).then((page) => [
-          filename,
-          page !== undefined,
-        ] as const)];
-      })),
-    );
+    const requestedHashes = [...new Set(filenames.flatMap((filename) => {
+      const hash = hashes?.[filename];
+      return hash ? [hash] : [];
+    }))];
+    const pagesByChecksum = await findPagesByChecksums(requestedHashes);
+    const observedChecksums = new Set(pagesByChecksum.flatMap((page) => (
+      page.checksumSha256 ? [page.checksumSha256] : []
+    )));
+    const contentDuplicates = Object.fromEntries(filenames.flatMap((filename) => {
+      const hash = hashes?.[filename];
+      return hash
+        ? [[filename, observedChecksums.has(hash)] as const]
+        : [];
+    }));
 
     res.json({ duplicates, sourceExpectations, contentDuplicates });
   } catch (error) {

--- a/backend/src/services/__tests__/content-checksum-lock.test.ts
+++ b/backend/src/services/__tests__/content-checksum-lock.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  queryMock,
+  releaseMock,
+  reserveMock,
+} = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  releaseMock: vi.fn(),
+  reserveMock: vi.fn(),
+}));
+
+vi.mock('../../db/index.js', () => {
+  const reserved = Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => (
+      queryMock([...strings], values)
+    ),
+    { release: releaseMock },
+  );
+  return {
+    sql: {
+      reserve: reserveMock.mockResolvedValue(reserved),
+    },
+  };
+});
+
+import { withContentChecksumLock } from '../content-checksum-lock.js';
+
+describe('content checksum session lock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockResolvedValue([]);
+  });
+
+  it('holds one reserved session and releases the checksum lock after failure', async () => {
+    await expect(withContentChecksumLock(
+      'checksum-a',
+      async () => {
+        throw new Error('upload failed');
+      },
+    )).rejects.toThrow('upload failed');
+
+    expect(reserveMock).toHaveBeenCalledOnce();
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(queryMock.mock.calls[0]?.[0].join('')).toContain('pg_advisory_lock');
+    expect(queryMock.mock.calls[1]?.[0].join('')).toContain('pg_advisory_unlock');
+    expect(queryMock.mock.calls[0]?.[1]).toEqual(['checksum-a']);
+    expect(queryMock.mock.calls[1]?.[1]).toEqual(['checksum-a']);
+    expect(releaseMock).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/services/__tests__/letter-pages.test.ts
+++ b/backend/src/services/__tests__/letter-pages.test.ts
@@ -50,6 +50,11 @@ const {
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ kind: 'eq', field, value })),
+  inArray: vi.fn((field: unknown, values: unknown[]) => ({
+    kind: 'inArray',
+    field,
+    values,
+  })),
   isNull: vi.fn((field: unknown) => ({ kind: 'isNull', field })),
   and: vi.fn((...clauses: unknown[]) => ({ kind: 'and', clauses })),
   or: vi.fn((...clauses: unknown[]) => ({ kind: 'or', clauses })),
@@ -143,8 +148,10 @@ vi.mock('../letter/correspondence-group.js', () => ({
 }));
 
 import {
+  findDurableContentDuplicateByIdentity,
   findOrCreatePage,
   findPageByChecksum,
+  findPagesByChecksums,
   getPage,
   getPagesByLetterId,
   updatePageDimensionsIfSourceCurrent,
@@ -958,6 +965,97 @@ describe('letter pages service', () => {
     expect(result).toEqual({
       id: 'page-checksum',
       checksumSha256: 'checksum-z',
+    });
+  });
+
+  it('prefers the requested page over a cross-identity checksum match', async () => {
+    const targetPage = {
+      id: 'page-target',
+      letterId: 'letter-1',
+      pageNumber: 1,
+      storagePath: 'storage/target.jpg',
+      checksumSha256: 'checksum-z',
+    };
+    findFirstMock.mockResolvedValueOnce(targetPage);
+    const isDurableSource = vi.fn().mockResolvedValue(true);
+
+    const result = await findDurableContentDuplicateByIdentity(
+      {
+        collectionId: 'collection-1',
+        dateRaw: '19470810',
+        type: 'L',
+        typeSequence: 1,
+        pageNumber: 1,
+      },
+      {
+        checksumSha256: 'checksum-z',
+        isDurableSource,
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(findManyMock).not.toHaveBeenCalled();
+    expect(isDurableSource).not.toHaveBeenCalled();
+  });
+
+  it('returns a locked and durable cross-identity checksum owner', async () => {
+    const duplicatePage = {
+      id: 'page-duplicate',
+      letterId: 'letter-1',
+      pageNumber: 4,
+      storagePath: 'storage/duplicate.jpg',
+      checksumSha256: 'checksum-z',
+    };
+    findManyMock.mockResolvedValueOnce([duplicatePage]);
+    findFirstMock.mockResolvedValue(duplicatePage);
+    const isDurableSource = vi.fn().mockResolvedValue(true);
+
+    const result = await findDurableContentDuplicateByIdentity(
+      {
+        dateRaw: '19500101',
+        type: 'L',
+        typeSequence: 1,
+        pageNumber: 1,
+      },
+      {
+        checksumSha256: 'checksum-z',
+        isDurableSource,
+      },
+    );
+
+    expect(result).toMatchObject({
+      letter: { id: 'letter-1' },
+      page: duplicatePage,
+      outcome: 'unchanged',
+      sourceChanged: false,
+    });
+    expect(lockCorrespondenceGroupByIdentityMock).toHaveBeenCalledWith(
+      {
+        collectionId: 'collection-1',
+        dateRaw: '19470810',
+        typeSequence: 1,
+      },
+      expect.any(Object),
+    );
+    expect(isDurableSource).toHaveBeenCalledWith(duplicatePage);
+  });
+
+  it('batches checksum lookups', async () => {
+    findManyMock.mockResolvedValueOnce([
+      { id: 'page-a', checksumSha256: 'checksum-a' },
+    ]);
+
+    const result = await findPagesByChecksums(['checksum-a', 'checksum-b']);
+
+    expect(result).toEqual([
+      { id: 'page-a', checksumSha256: 'checksum-a' },
+    ]);
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        kind: 'inArray',
+        field: 'letterPages.checksumSha256',
+        values: ['checksum-a', 'checksum-b'],
+      },
     });
   });
 

--- a/backend/src/services/__tests__/upload.test.ts
+++ b/backend/src/services/__tests__/upload.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   findOrCreateCollectionMock,
+  getCollectionByIdMock,
   findLetterByIdentityMock,
+  getLetterByIdMock,
+  findPageByChecksumMock,
   findOrCreatePageMock,
   getPageMock,
   computeChecksumMock,
@@ -16,7 +19,10 @@ const {
   storeImmutableFileMock,
 } = vi.hoisted(() => ({
   findOrCreateCollectionMock: vi.fn(),
+  getCollectionByIdMock: vi.fn(),
   findLetterByIdentityMock: vi.fn(),
+  getLetterByIdMock: vi.fn(),
+  findPageByChecksumMock: vi.fn(),
   findOrCreatePageMock: vi.fn(),
   getPageMock: vi.fn(),
   computeChecksumMock: vi.fn(),
@@ -32,13 +38,16 @@ const {
 
 vi.mock('../collections.js', () => ({
   findOrCreateCollection: findOrCreateCollectionMock,
+  getCollectionById: getCollectionByIdMock,
 }));
 
 vi.mock('../letters.js', () => ({
   findLetterByIdentity: findLetterByIdentityMock,
+  getLetterById: getLetterByIdMock,
 }));
 
 vi.mock('../letter-pages.js', () => ({
+  findPageByChecksum: findPageByChecksumMock,
   findOrCreatePage: findOrCreatePageMock,
   getPage: getPageMock,
 }));
@@ -134,6 +143,7 @@ describe('upload service', () => {
       collectionCode: '003',
     });
     findLetterByIdentityMock.mockResolvedValue(observedLetter);
+    findPageByChecksumMock.mockResolvedValue(undefined);
     getPageMock.mockResolvedValue(undefined);
     findOrCreatePageMock.mockResolvedValue(pageMutationResult({
       page: {
@@ -165,6 +175,91 @@ describe('upload service', () => {
 
     expect(findOrCreateCollectionMock).not.toHaveBeenCalled();
     expect(storeImmutableFileMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing owner for renamed content before creating membership', async () => {
+    const existingPage = {
+      id: 'page-existing-content',
+      letterId: 'letter-existing-content',
+      pageNumber: 5,
+      storagePath: 'storage/collections/004/objects/existing.jpg',
+      originalFilename: '004-19400102-L01-05.jpg',
+      checksumSha256: 'abc123',
+    };
+    const existingLetter = {
+      id: 'letter-existing-content',
+      collectionId: 'collection-existing-content',
+      dateRaw: '19400102',
+      type: 'L',
+      typeSequence: 1,
+      primarySourceRevision: 9,
+    };
+    const existingCollection = {
+      id: 'collection-existing-content',
+      collectionCode: '004',
+    };
+    findPageByChecksumMock.mockResolvedValueOnce(existingPage);
+    getLetterByIdMock.mockResolvedValueOnce(existingLetter);
+    getCollectionByIdMock.mockResolvedValueOnce(existingCollection);
+
+    const result = await processUploadedFile(
+      '/tmp/renamed.jpg',
+      '003-19320706-L01-01.jpg',
+    );
+
+    expect(findPageByChecksumMock).toHaveBeenCalledWith('abc123');
+    expect(findOrCreateCollectionMock).not.toHaveBeenCalled();
+    expect(findLetterByIdentityMock).not.toHaveBeenCalled();
+    expect(storeImmutableFileMock).not.toHaveBeenCalled();
+    expect(findOrCreatePageMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      collection: existingCollection,
+      letter: existingLetter,
+      page: existingPage,
+      storagePath: existingPage.storagePath,
+      primarySourceRevision: 9,
+      alreadyExists: true,
+      outcome: 'unchanged',
+      changed: false,
+      duplicateReason: 'duplicate_content',
+    });
+  });
+
+  it('keeps normal reconciliation for matching content at the requested identity', async () => {
+    const sameIdentityPage = {
+      ...preflightExistingPage,
+      pageNumber: 1,
+      checksumSha256: 'abc123',
+    };
+    findPageByChecksumMock.mockResolvedValueOnce(sameIdentityPage);
+    getLetterByIdMock.mockResolvedValueOnce({
+      ...observedLetter,
+      primarySourceRevision: 7,
+    });
+    getCollectionByIdMock.mockResolvedValueOnce({
+      id: 'collection-1',
+      collectionCode: '003',
+    });
+    getPageMock.mockResolvedValueOnce(sameIdentityPage);
+    findOrCreatePageMock.mockResolvedValueOnce(pageMutationResult({
+      page: sameIdentityPage,
+      outcome: 'unchanged',
+      sourceChanged: false,
+      primarySourceRevision: 7,
+    }));
+
+    const result = await processUploadedFile(
+      '/tmp/test.jpg',
+      '003-19320706-L01-01.jpg',
+    );
+
+    expect(findOrCreateCollectionMock).toHaveBeenCalledWith('003');
+    expect(findOrCreatePageMock).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      outcome: 'unchanged',
+      changed: false,
+    });
+    expect(result).not.toHaveProperty('duplicateReason');
   });
 
   it('passes the read-only observed letter and exact creation identity to the page owner', async () => {

--- a/backend/src/services/__tests__/upload.test.ts
+++ b/backend/src/services/__tests__/upload.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   findOrCreateCollectionMock,
+  getCollectionByCodeMock,
   getCollectionByIdMock,
   findLetterByIdentityMock,
-  getLetterByIdMock,
-  findPageByChecksumMock,
+  findDurableContentDuplicateByIdentityMock,
   findOrCreatePageMock,
   getPageMock,
   computeChecksumMock,
@@ -17,12 +17,13 @@ const {
   reclaimStoragePathMock,
   removeStoredFileMock,
   storeImmutableFileMock,
+  withContentChecksumLockMock,
 } = vi.hoisted(() => ({
   findOrCreateCollectionMock: vi.fn(),
+  getCollectionByCodeMock: vi.fn(),
   getCollectionByIdMock: vi.fn(),
   findLetterByIdentityMock: vi.fn(),
-  getLetterByIdMock: vi.fn(),
-  findPageByChecksumMock: vi.fn(),
+  findDurableContentDuplicateByIdentityMock: vi.fn(),
   findOrCreatePageMock: vi.fn(),
   getPageMock: vi.fn(),
   computeChecksumMock: vi.fn(),
@@ -34,22 +35,28 @@ const {
   reclaimStoragePathMock: vi.fn(),
   removeStoredFileMock: vi.fn(),
   storeImmutableFileMock: vi.fn(),
+  withContentChecksumLockMock: vi.fn(),
 }));
 
 vi.mock('../collections.js', () => ({
   findOrCreateCollection: findOrCreateCollectionMock,
+  getCollectionByCode: getCollectionByCodeMock,
   getCollectionById: getCollectionByIdMock,
 }));
 
 vi.mock('../letters.js', () => ({
   findLetterByIdentity: findLetterByIdentityMock,
-  getLetterById: getLetterByIdMock,
 }));
 
 vi.mock('../letter-pages.js', () => ({
-  findPageByChecksum: findPageByChecksumMock,
+  findDurableContentDuplicateByIdentity:
+    findDurableContentDuplicateByIdentityMock,
   findOrCreatePage: findOrCreatePageMock,
   getPage: getPageMock,
+}));
+
+vi.mock('../content-checksum-lock.js', () => ({
+  withContentChecksumLock: withContentChecksumLockMock,
 }));
 
 vi.mock('../storage-reference-cleanup.js', () => ({
@@ -142,8 +149,13 @@ describe('upload service', () => {
       id: 'collection-1',
       collectionCode: '003',
     });
+    getCollectionByCodeMock.mockResolvedValue(undefined);
+    getCollectionByIdMock.mockResolvedValue({
+      id: 'collection-1',
+      collectionCode: '003',
+    });
     findLetterByIdentityMock.mockResolvedValue(observedLetter);
-    findPageByChecksumMock.mockResolvedValue(undefined);
+    findDurableContentDuplicateByIdentityMock.mockResolvedValue(undefined);
     getPageMock.mockResolvedValue(undefined);
     findOrCreatePageMock.mockResolvedValue(pageMutationResult({
       page: {
@@ -166,6 +178,9 @@ describe('upload service', () => {
     computeChecksumMock.mockResolvedValue('abc123');
     reclaimStoragePathMock.mockResolvedValue('removed');
     removeStoredFileMock.mockResolvedValue(undefined);
+    withContentChecksumLockMock.mockImplementation(
+      async (_checksum: string, work: () => Promise<unknown>) => work(),
+    );
   });
 
   it('rejects invalid filenames before touching downstream services', async () => {
@@ -177,7 +192,7 @@ describe('upload service', () => {
     expect(storeImmutableFileMock).not.toHaveBeenCalled();
   });
 
-  it('returns the existing owner for renamed content before creating membership', async () => {
+  it('returns a durable renamed-content owner before creating membership', async () => {
     const existingPage = {
       id: 'page-existing-content',
       letterId: 'letter-existing-content',
@@ -198,8 +213,13 @@ describe('upload service', () => {
       id: 'collection-existing-content',
       collectionCode: '004',
     };
-    findPageByChecksumMock.mockResolvedValueOnce(existingPage);
-    getLetterByIdMock.mockResolvedValueOnce(existingLetter);
+    findDurableContentDuplicateByIdentityMock.mockResolvedValueOnce({
+      letter: existingLetter,
+      page: existingPage,
+      outcome: 'unchanged',
+      sourceChanged: false,
+      primarySourceRevision: 9,
+    });
     getCollectionByIdMock.mockResolvedValueOnce(existingCollection);
 
     const result = await processUploadedFile(
@@ -207,7 +227,22 @@ describe('upload service', () => {
       '003-19320706-L01-01.jpg',
     );
 
-    expect(findPageByChecksumMock).toHaveBeenCalledWith('abc123');
+    expect(withContentChecksumLockMock).toHaveBeenCalledWith(
+      'abc123',
+      expect.any(Function),
+    );
+    expect(findDurableContentDuplicateByIdentityMock).toHaveBeenCalledWith(
+      {
+        dateRaw: '19320706',
+        type: 'L',
+        typeSequence: 1,
+        pageNumber: 1,
+      },
+      {
+        checksumSha256: 'abc123',
+        isDurableSource: expect.any(Function),
+      },
+    );
     expect(findOrCreateCollectionMock).not.toHaveBeenCalled();
     expect(findLetterByIdentityMock).not.toHaveBeenCalled();
     expect(storeImmutableFileMock).not.toHaveBeenCalled();
@@ -231,12 +266,7 @@ describe('upload service', () => {
       pageNumber: 1,
       checksumSha256: 'abc123',
     };
-    findPageByChecksumMock.mockResolvedValueOnce(sameIdentityPage);
-    getLetterByIdMock.mockResolvedValueOnce({
-      ...observedLetter,
-      primarySourceRevision: 7,
-    });
-    getCollectionByIdMock.mockResolvedValueOnce({
+    getCollectionByCodeMock.mockResolvedValueOnce({
       id: 'collection-1',
       collectionCode: '003',
     });
@@ -253,13 +283,126 @@ describe('upload service', () => {
       '003-19320706-L01-01.jpg',
     );
 
-    expect(findOrCreateCollectionMock).toHaveBeenCalledWith('003');
+    expect(findDurableContentDuplicateByIdentityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionId: 'collection-1',
+        pageNumber: 1,
+      }),
+      expect.any(Object),
+    );
+    expect(findOrCreateCollectionMock).not.toHaveBeenCalled();
     expect(findOrCreatePageMock).toHaveBeenCalled();
     expect(result).toMatchObject({
       outcome: 'unchanged',
       changed: false,
     });
     expect(result).not.toHaveProperty('duplicateReason');
+  });
+
+  it.each([
+    ['missing', new Error('missing object')],
+    ['corrupt', 'different-checksum'],
+  ])(
+    'does not discard an upload when a checksum claimant is %s',
+    async (_label, checksumResult) => {
+      const claimant = {
+        id: 'page-broken-content',
+        letterId: 'letter-broken-content',
+        storagePath: 'storage/objects/broken.jpg',
+        checksumSha256: 'abc123',
+      };
+      if (checksumResult instanceof Error) {
+        computeChecksumMock.mockRejectedValueOnce(checksumResult);
+      } else {
+        computeChecksumMock.mockResolvedValueOnce(checksumResult);
+      }
+      findDurableContentDuplicateByIdentityMock.mockImplementationOnce(
+        async (_identity, lookup) => {
+          expect(await lookup.isDurableSource(claimant)).toBe(false);
+          return undefined;
+        },
+      );
+
+      const result = await processUploadedFile(
+        '/tmp/renamed.jpg',
+        '003-19320706-L01-01.jpg',
+      );
+
+      expect(result).toMatchObject({
+        page: { id: 'page-1' },
+        outcome: 'created',
+        changed: true,
+      });
+      expect(result).not.toHaveProperty('duplicateReason');
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          existingPageId: claimant.id,
+        }),
+        expect.stringContaining('missing or corrupt'),
+      );
+    },
+  );
+
+  it('serializes first writers through duplicate lookup before collection creation', async () => {
+    let releasePrevious = Promise.resolve();
+    withContentChecksumLockMock.mockImplementation(
+      async (_checksum: string, work: () => Promise<unknown>) => {
+        const waitForPrevious = releasePrevious;
+        let releaseCurrent!: () => void;
+        releasePrevious = new Promise<void>((resolve) => {
+          releaseCurrent = resolve;
+        });
+        await waitForPrevious;
+        try {
+          return await work();
+        } finally {
+          releaseCurrent();
+        }
+      },
+    );
+
+    let committed = false;
+    const committedPage = {
+      id: 'page-1',
+      letterId: 'letter-1',
+      pageNumber: 1,
+      storagePath: 'storage/objects/source-a.jpg',
+      checksumSha256: 'abc123',
+    };
+    findDurableContentDuplicateByIdentityMock.mockImplementation(async () => (
+      committed
+        ? {
+            letter: { ...observedLetter, primarySourceRevision: 1 },
+            page: committedPage,
+            outcome: 'unchanged',
+            sourceChanged: false,
+            primarySourceRevision: 1,
+          }
+        : undefined
+    ));
+    findOrCreatePageMock.mockImplementationOnce(async () => {
+      committed = true;
+      return pageMutationResult({
+        page: committedPage,
+        outcome: 'created',
+        sourceChanged: true,
+        primarySourceRevision: 1,
+      });
+    });
+
+    const [winner, contender] = await Promise.all([
+      processUploadedFile('/tmp/first.jpg', '003-19320706-L01-01.jpg'),
+      processUploadedFile('/tmp/second.jpg', '004-19400102-L01-01.jpg'),
+    ]);
+
+    expect(winner).toMatchObject({ outcome: 'created' });
+    expect(contender).toMatchObject({
+      outcome: 'unchanged',
+      duplicateReason: 'duplicate_content',
+    });
+    expect(findOrCreateCollectionMock).toHaveBeenCalledTimes(1);
+    expect(storeImmutableFileMock).toHaveBeenCalledTimes(1);
+    expect(findOrCreatePageMock).toHaveBeenCalledTimes(1);
   });
 
   it('passes the read-only observed letter and exact creation identity to the page owner', async () => {

--- a/backend/src/services/content-checksum-lock.ts
+++ b/backend/src/services/content-checksum-lock.ts
@@ -1,0 +1,35 @@
+import { sql } from '../db/index.js';
+
+/**
+ * Holds one PostgreSQL session for the complete non-force checksum workflow.
+ * Transaction-scoped locks inside individual read/write helpers cannot cover
+ * the gap between duplicate preflight and first collection/page creation.
+ */
+export async function withContentChecksumLock<T>(
+  checksumSha256: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  const reserved = await sql.reserve();
+  let locked = false;
+  try {
+    await reserved`
+      SELECT pg_advisory_lock(
+        hashtextextended(${checksumSha256}, 0)
+      )
+    `;
+    locked = true;
+    return await work();
+  } finally {
+    try {
+      if (locked) {
+        await reserved`
+          SELECT pg_advisory_unlock(
+            hashtextextended(${checksumSha256}, 0)
+          )
+        `;
+      }
+    } finally {
+      reserved.release();
+    }
+  }
+}

--- a/backend/src/services/letter-pages.ts
+++ b/backend/src/services/letter-pages.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull, or } from 'drizzle-orm';
+import { eq, and, inArray, isNull, or } from 'drizzle-orm';
 import {
   collections,
   db,
@@ -97,6 +97,19 @@ export interface ObservedPageSource {
   checksumSha256: string | null;
 }
 
+export interface ContentDuplicateIdentity {
+  collectionId?: string;
+  dateRaw: string;
+  type: LetterType;
+  typeSequence: number;
+  pageNumber: number;
+}
+
+export interface DurableContentLookup {
+  checksumSha256: string;
+  isDurableSource: (page: LetterPage) => Promise<boolean>;
+}
+
 export function uploadPageIdentityKey(identity: UploadPageIdentity): string {
   return [
     identity.collectionCode,
@@ -191,6 +204,103 @@ async function loadLockedLetter(
     throw new Error(`Locked page source owner ${letterId} could not be reloaded`);
   }
   return letter;
+}
+
+/**
+ * Finds a durable page with matching content while preserving target identity.
+ *
+ * The caller must hold the checksum-scoped advisory lock for the full upload
+ * workflow. This transaction locks any requested or matching correspondence
+ * group so force replacement cannot invalidate the duplicate decision while
+ * its stored object is being verified.
+ */
+export async function findDurableContentDuplicateByIdentity(
+  identity: ContentDuplicateIdentity,
+  lookup: DurableContentLookup,
+): Promise<PageMutationResult | undefined> {
+  return db.transaction(async (tx) => {
+    if (identity.collectionId) {
+      const targetGroup = await lockCorrespondenceGroupByIdentity(
+        {
+          collectionId: identity.collectionId,
+          dateRaw: identity.dateRaw,
+          typeSequence: identity.typeSequence,
+        },
+        tx,
+      );
+      const targetOwner = targetGroup?.members.find(
+        (member) => member.type === identity.type,
+      );
+      const targetPage = targetOwner
+        ? await tx.query.letterPages.findFirst({
+            where: and(
+              eq(letterPages.letterId, targetOwner.id),
+              eq(letterPages.pageNumber, identity.pageNumber),
+            ),
+          })
+        : undefined;
+      if (targetPage) return undefined;
+    }
+
+    const matchingPages = await tx.query.letterPages.findMany({
+      where: eq(letterPages.checksumSha256, lookup.checksumSha256),
+    });
+    for (const observedPage of matchingPages) {
+      const observedOwner = await tx.query.letters.findFirst({
+        where: eq(letters.id, observedPage.letterId),
+      });
+      if (!observedOwner) continue;
+
+      const ownerGroup = await lockCorrespondenceGroupByIdentity(
+        {
+          collectionId: observedOwner.collectionId,
+          dateRaw: observedOwner.dateRaw,
+          typeSequence: observedOwner.typeSequence,
+        },
+        tx,
+      );
+      if (
+        !ownerGroup
+        || !ownerGroup.members.some((member) => member.id === observedOwner.id)
+      ) {
+        continue;
+      }
+
+      const currentPage = await tx.query.letterPages.findFirst({
+        where: eq(letterPages.id, observedPage.id),
+      });
+      if (
+        !currentPage
+        || currentPage.letterId !== observedPage.letterId
+        || currentPage.storagePath !== observedPage.storagePath
+        || currentPage.checksumSha256 !== lookup.checksumSha256
+        || !(await lookup.isDurableSource(currentPage))
+      ) {
+        continue;
+      }
+
+      const confirmedPage = await tx.query.letterPages.findFirst({
+        where: eq(letterPages.id, currentPage.id),
+      });
+      const confirmedOwner = await loadLockedLetter(observedOwner.id, tx);
+      if (
+        confirmedPage
+        && confirmedPage.letterId === confirmedOwner.id
+        && confirmedPage.storagePath === currentPage.storagePath
+        && confirmedPage.checksumSha256 === lookup.checksumSha256
+      ) {
+        return {
+          letter: confirmedOwner,
+          page: confirmedPage,
+          outcome: 'unchanged',
+          sourceChanged: false,
+          primarySourceRevision: confirmedOwner.primarySourceRevision,
+        };
+      }
+    }
+
+    return undefined;
+  });
 }
 
 async function resolvePageOwner(
@@ -532,5 +642,15 @@ export async function getPage(
 export async function findPageByChecksum(checksum: string): Promise<LetterPage | undefined> {
   return db.query.letterPages.findFirst({
     where: eq(letterPages.checksumSha256, checksum),
+  });
+}
+
+/**
+ * Gets every page matching any checksum in one query.
+ */
+export async function findPagesByChecksums(checksums: string[]): Promise<LetterPage[]> {
+  if (checksums.length === 0) return [];
+  return db.query.letterPages.findMany({
+    where: inArray(letterPages.checksumSha256, checksums),
   });
 }

--- a/backend/src/services/upload.ts
+++ b/backend/src/services/upload.ts
@@ -9,14 +9,17 @@ import {
   removeStoredFile,
   storeImmutableFile,
 } from './storage.js';
-import { findOrCreateCollection, getCollectionById } from './collections.js';
+import {
+  findOrCreateCollection,
+  getCollectionByCode,
+  getCollectionById,
+} from './collections.js';
 import {
   findLetterByIdentity,
-  getLetterById,
   type CreateLetterParams,
 } from './letters.js';
 import {
-  findPageByChecksum,
+  findDurableContentDuplicateByIdentity,
   findOrCreatePage,
   getPage,
   type ExistingPagePolicy,
@@ -31,6 +34,7 @@ import {
   sourceRevisionChanged,
 } from './letter/source-revision.js';
 import { reclaimUnreferencedPageStoragePath } from './storage-reference-cleanup.js';
+import { withContentChecksumLock } from './content-checksum-lock.js';
 
 const log = createLogger({ module: 'upload' });
 
@@ -66,6 +70,18 @@ function uploadOutcome(outcome: PageMutationOutcome): UploadOutcome {
   return 'unchanged';
 }
 
+async function isDurableChecksumSource(
+  page: LetterPage,
+  checksumSha256: string,
+): Promise<boolean> {
+  try {
+    return await computeChecksum(getAbsoluteStoragePath(page.storagePath))
+      === checksumSha256;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Processes an uploaded file:
  * 1. Parses the filename
@@ -76,11 +92,13 @@ function uploadOutcome(outcome: PageMutationOutcome): UploadOutcome {
  *
  * @param force - If true, overwrites existing files instead of skipping
  */
-export async function processUploadedFile(
+async function processUploadedFileInternal(
   tempPath: string,
   originalFilename: string,
   force = false,
   expectedReplacementSource?: UploadSourceExpectation,
+  contentLockHeld = false,
+  inspectedFile?: Awaited<ReturnType<typeof inspectUploadFile>>,
 ): Promise<UploadResult> {
   const start = Date.now();
   const context = { originalFilename, force };
@@ -113,70 +131,92 @@ export async function processUploadedFile(
     'Filename parsed successfully'
   );
 
-  // Resolve content duplicates before creating collection or letter membership.
-  // A renamed upload can parse to a different identity even when its bytes are
-  // already archived, and creating that identity first would leave page-less
-  // metadata behind when the upload short-circuits.
-  const inspectedUpload = force ? null : await inspectUploadFile(tempPath);
-  if (inspectedUpload) {
-    const existingByChecksum = await findPageByChecksum(
+  const inspectedUpload = force
+    ? null
+    : inspectedFile ?? await inspectUploadFile(tempPath);
+  if (inspectedUpload && !contentLockHeld) {
+    return withContentChecksumLock(
       inspectedUpload.checksumSha256,
+      () => processUploadedFileInternal(
+        tempPath,
+        originalFilename,
+        force,
+        expectedReplacementSource,
+        true,
+        inspectedUpload,
+      ),
     );
-    if (existingByChecksum) {
-      const existingLetter = await getLetterById(existingByChecksum.letterId);
-      const existingCollection = existingLetter
-        ? await getCollectionById(existingLetter.collectionId)
-        : undefined;
-      const samePageIdentity = Boolean(
-        existingLetter
-        && existingCollection
-        && existingCollection.collectionCode === parsed.collectionCode
-        && existingLetter.dateRaw === parsed.dateRaw
-        && existingLetter.type === parsed.type
-        && existingLetter.typeSequence === parsed.typeSequence
-        && existingByChecksum.pageNumber === parsed.pageNumber
-      );
-
-      if (existingLetter && existingCollection && !samePageIdentity) {
-        log.info(
-          {
-            ...context,
-            checksumSha256:
-              inspectedUpload.checksumSha256.substring(0, 12) + '...',
-            existingPageId: existingByChecksum.id,
-            existingStoragePath: existingByChecksum.storagePath,
-          },
-          'Content-hash duplicate, skipping storage and membership writes',
-        );
-        return {
-          collection: existingCollection,
-          letter: existingLetter,
-          page: existingByChecksum,
-          storagePath: existingByChecksum.storagePath,
-          primarySourceRevision: existingLetter.primarySourceRevision,
-          alreadyExists: true,
-          outcome: 'unchanged',
-          changed: false,
-          duplicateReason: 'duplicate_content',
-        };
-      }
-
-      if (!existingLetter || !existingCollection) {
-        log.warn(
-          {
-            ...context,
-            existingPageId: existingByChecksum.id,
-            letterFound: Boolean(existingLetter),
-            collectionFound: Boolean(existingCollection),
-          },
-          'Content-hash match has no complete owner; continuing normal upload reconciliation',
-        );
-      }
-    }
   }
 
-  // Get or create collection
-  const collection = await findOrCreateCollection(parsed.collectionCode);
+  const observedCollection = await getCollectionByCode(parsed.collectionCode);
+  const duplicate = inspectedUpload
+    ? await findDurableContentDuplicateByIdentity(
+        {
+          ...(observedCollection ? { collectionId: observedCollection.id } : {}),
+          dateRaw: parsed.dateRaw,
+          type: parsed.type,
+          typeSequence: parsed.typeSequence,
+          pageNumber: parsed.pageNumber,
+        },
+        {
+          checksumSha256: inspectedUpload.checksumSha256,
+          isDurableSource: async (page) => {
+            const durable = await isDurableChecksumSource(
+              page,
+              inspectedUpload.checksumSha256,
+            );
+            if (!durable) {
+              log.warn(
+                {
+                  ...context,
+                  existingPageId: page.id,
+                  existingStoragePath: page.storagePath,
+                },
+                'Ignoring a content-hash match whose archived object is missing or corrupt',
+              );
+            }
+            return durable;
+          },
+        },
+      )
+    : undefined;
+  if (duplicate) {
+    const duplicateCollection = await getCollectionById(
+      duplicate.letter.collectionId,
+    );
+    if (!duplicateCollection) {
+      throw new Error(
+        `Content duplicate owner collection ${duplicate.letter.collectionId} could not be loaded`,
+      );
+    }
+    log.info(
+      {
+        ...context,
+        collectionId: duplicateCollection.id,
+        letterId: duplicate.letter.id,
+        pageId: duplicate.page.id,
+        alreadyExists: true,
+        outcome: 'unchanged',
+        changed: false,
+        duration: Date.now() - start,
+      },
+      'Upload source unchanged',
+    );
+    return {
+      collection: duplicateCollection,
+      letter: duplicate.letter,
+      page: duplicate.page,
+      storagePath: duplicate.page.storagePath,
+      primarySourceRevision: duplicate.primarySourceRevision,
+      alreadyExists: true,
+      outcome: 'unchanged',
+      changed: false,
+      duplicateReason: 'duplicate_content',
+    };
+  }
+
+  const collection = observedCollection
+    ?? await findOrCreateCollection(parsed.collectionCode);
   log.debug({ ...context, collectionId: collection.id }, 'Collection resolved');
 
   const letterIdentity: CreateLetterParams = {
@@ -465,4 +505,18 @@ export async function processUploadedFile(
     outcome,
     changed: pageResult.sourceChanged,
   };
+}
+
+export async function processUploadedFile(
+  tempPath: string,
+  originalFilename: string,
+  force = false,
+  expectedReplacementSource?: UploadSourceExpectation,
+): Promise<UploadResult> {
+  return processUploadedFileInternal(
+    tempPath,
+    originalFilename,
+    force,
+    expectedReplacementSource,
+  );
 }

--- a/backend/src/services/upload.ts
+++ b/backend/src/services/upload.ts
@@ -9,12 +9,14 @@ import {
   removeStoredFile,
   storeImmutableFile,
 } from './storage.js';
-import { findOrCreateCollection } from './collections.js';
+import { findOrCreateCollection, getCollectionById } from './collections.js';
 import {
   findLetterByIdentity,
+  getLetterById,
   type CreateLetterParams,
 } from './letters.js';
 import {
+  findPageByChecksum,
   findOrCreatePage,
   getPage,
   type ExistingPagePolicy,
@@ -41,9 +43,11 @@ export interface UploadResult {
   alreadyExists: boolean;
   outcome: UploadOutcome;
   changed: boolean;
+  duplicateReason?: DuplicateReason;
 }
 
 export type UploadOutcome = 'created' | 'replaced' | 'unchanged';
+export type DuplicateReason = 'duplicate_content';
 
 async function readImageDimensions(
   storagePath: string,
@@ -108,6 +112,68 @@ export async function processUploadedFile(
     },
     'Filename parsed successfully'
   );
+
+  // Resolve content duplicates before creating collection or letter membership.
+  // A renamed upload can parse to a different identity even when its bytes are
+  // already archived, and creating that identity first would leave page-less
+  // metadata behind when the upload short-circuits.
+  const inspectedUpload = force ? null : await inspectUploadFile(tempPath);
+  if (inspectedUpload) {
+    const existingByChecksum = await findPageByChecksum(
+      inspectedUpload.checksumSha256,
+    );
+    if (existingByChecksum) {
+      const existingLetter = await getLetterById(existingByChecksum.letterId);
+      const existingCollection = existingLetter
+        ? await getCollectionById(existingLetter.collectionId)
+        : undefined;
+      const samePageIdentity = Boolean(
+        existingLetter
+        && existingCollection
+        && existingCollection.collectionCode === parsed.collectionCode
+        && existingLetter.dateRaw === parsed.dateRaw
+        && existingLetter.type === parsed.type
+        && existingLetter.typeSequence === parsed.typeSequence
+        && existingByChecksum.pageNumber === parsed.pageNumber
+      );
+
+      if (existingLetter && existingCollection && !samePageIdentity) {
+        log.info(
+          {
+            ...context,
+            checksumSha256:
+              inspectedUpload.checksumSha256.substring(0, 12) + '...',
+            existingPageId: existingByChecksum.id,
+            existingStoragePath: existingByChecksum.storagePath,
+          },
+          'Content-hash duplicate, skipping storage and membership writes',
+        );
+        return {
+          collection: existingCollection,
+          letter: existingLetter,
+          page: existingByChecksum,
+          storagePath: existingByChecksum.storagePath,
+          primarySourceRevision: existingLetter.primarySourceRevision,
+          alreadyExists: true,
+          outcome: 'unchanged',
+          changed: false,
+          duplicateReason: 'duplicate_content',
+        };
+      }
+
+      if (!existingLetter || !existingCollection) {
+        log.warn(
+          {
+            ...context,
+            existingPageId: existingByChecksum.id,
+            letterFound: Boolean(existingLetter),
+            collectionFound: Boolean(existingCollection),
+          },
+          'Content-hash match has no complete owner; continuing normal upload reconciliation',
+        );
+      }
+    }
+  }
 
   // Get or create collection
   const collection = await findOrCreateCollection(parsed.collectionCode);
@@ -259,7 +325,7 @@ export async function processUploadedFile(
     ) {
       pageResult = await commitObservedSource(actualChecksum, 'keep');
     } else {
-      const inspected = await inspectUploadFile(tempPath);
+      const inspected = inspectedUpload ?? await inspectUploadFile(tempPath);
       if (inspected.checksumSha256 === existing.checksumSha256) {
         const stored = await storeImmutableFile(
           tempPath,
@@ -294,7 +360,7 @@ export async function processUploadedFile(
       }
     }
   } else {
-    const inspected = await inspectUploadFile(tempPath);
+    const inspected = inspectedUpload ?? await inspectUploadFile(tempPath);
 
     if (existing) {
       let actualChecksum: string | null = null;

--- a/frontend/src/api/admin/upload.ts
+++ b/frontend/src/api/admin/upload.ts
@@ -1,5 +1,7 @@
 import { apiPost } from "../client";
 
+export type DuplicateReason = "duplicate_content";
+
 export interface UploadResult {
   filename: string;
   letterId: string;
@@ -10,6 +12,7 @@ export interface UploadResult {
   alreadyExists: boolean;
   outcome: "created" | "replaced" | "unchanged";
   changed: boolean;
+  duplicateReason?: DuplicateReason;
 }
 
 export interface UploadError {
@@ -58,8 +61,15 @@ export async function uploadFiles(
 export interface CheckDuplicatesResponse {
   duplicates: Record<string, boolean>;
   sourceExpectations: Record<string, UploadSourceExpectation | null>;
+  contentDuplicates: Record<string, boolean>;
 }
 
-export async function checkDuplicates(filenames: string[]): Promise<CheckDuplicatesResponse> {
-  return apiPost<CheckDuplicatesResponse>("/admin/uploads/check-duplicates", { filenames });
+export async function checkDuplicates(
+  filenames: string[],
+  hashes?: Record<string, string>,
+): Promise<CheckDuplicatesResponse> {
+  return apiPost<CheckDuplicatesResponse>(
+    "/admin/uploads/check-duplicates",
+    hashes ? { filenames, hashes } : { filenames },
+  );
 }


### PR DESCRIPTION
## Summary

Prevents the same scanned image from being archived twice when it is uploaded under a different valid filename.

- Inspects non-force uploads before creating collection or letter membership.
- Reuses the existing `letter_pages.checksum_sha256` field; no schema migration is needed.
- Returns the authoritative existing collection, letter, and page with `duplicateReason: "duplicate_content"`.
- Preserves normal reconciliation when the upload targets the same page identity.
- Verifies that a checksum claimant's stored object still exists and matches before skipping a good upload.
- Serializes same-content uploads through a checksum-scoped PostgreSQL advisory lock, so concurrent first writers cannot both commit.
- Validates and batches optional preflight hashes in `POST /admin/uploads/check-duplicates`.

The optional frontend `hashes` argument remains an API hook for a future client-side hashing UX. The upload endpoint itself enforces content deduplication, so existing filename-only callers are protected.

## Review fixes

The branch was rebased onto current `main` and reviewed in parallel for backend integrity, API/security, and regressions. The resulting fixes address:

- orphan collection/letter creation before a content duplicate short-circuit;
- concurrent same-content uploads racing through preflight;
- stale checksum rows whose archived object is missing or corrupt;
- ambiguous ownership when multiple page identities share a checksum;
- malformed or unbounded hash-preflight payloads;
- per-file checksum lookup fan-out.

## Validation

- [x] Backend: 111 test files, 1,176 tests passed
- [x] Backend typecheck passed
- [x] Frontend: 155 test files, 1,098 tests passed with one worker
- [x] Frontend production build passed
- [x] Targeted lint for the changed frontend upload API passed
- [x] `git diff --check` passed

## Notes

`letter_pages.checksum_sha256` already stores the SHA-256 content identity and is indexed, so adding a second content-hash column would duplicate existing data. Historical rows without a checksum continue through the normal upload path.
