### PR TITLE
fix(worker): repair startup regressions

### DIFF
--- a/backend/src/db/__tests__/migrations.test.ts
+++ b/backend/src/db/__tests__/migrations.test.ts
@@ -224,6 +224,47 @@ describe("migration validation", () => {
     expect(sql).not.toMatch(/DEFAULT\s+gen_random_uuid/i);
   });
 
+  it("repairs extra-content ownership for databases that already advanced past 0045", () => {
+    const journal = readJournal();
+    const transcriptIntent = journal.entries.find(
+      (entry) => entry.tag === "0055_add_transcript_confirmation_intent",
+    );
+    const ownershipRepair = journal.entries.find(
+      (entry) => entry.tag === "0056_repair_extra_content_job_ownership",
+    );
+    const sql = readMigrationSql("0056_repair_extra_content_job_ownership");
+
+    expect(ownershipRepair).toBeDefined();
+    expect(ownershipRepair!.idx).toBe(transcriptIntent!.idx + 1);
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "extra_content_job_run_id" uuid',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "extra_content_job_dirty" boolean DEFAULT false NOT NULL',
+    );
+    expect(sql).toContain(
+      'ALTER COLUMN "extra_content_job_dirty" SET DEFAULT false',
+    );
+    expect(sql).toContain(
+      'ALTER COLUMN "extra_content_job_dirty" SET NOT NULL',
+    );
+    expect(sql).toMatch(
+      /UPDATE\s+"letters"[\s\S]*?"extra_content_job_status"\s*=\s*'PENDING'[\s\S]*?WHERE\s+"extra_content_job_status"\s*=\s*'RUNNING'[\s\S]*?"extra_content_job_run_id"\s+IS\s+NULL/i,
+    );
+    expect(sql).toContain(
+      'ADD CONSTRAINT "extra_content_job_run_id_matches_running"',
+    );
+    expect(sql).toContain(
+      'ADD CONSTRAINT "extra_content_job_dirty_requires_running"',
+    );
+    expect(sql).toContain(
+      'VALIDATE CONSTRAINT "extra_content_job_run_id_matches_running"',
+    );
+    expect(sql).toContain(
+      'VALIDATE CONSTRAINT "extra_content_job_dirty_requires_running"',
+    );
+  });
+
   it("orders entity extraction liveness after the ownership rollout boundaries", () => {
     const journal = readJournal();
     const commitBoundary = journal.entries.find(

--- a/backend/src/db/migrations/0056_repair_extra_content_job_ownership.sql
+++ b/backend/src/db/migrations/0056_repair_extra_content_job_ownership.sql
@@ -1,0 +1,92 @@
+-- 0045 was reused during development after some databases had already
+-- recorded its journal timestamp. Those databases advanced through later
+-- migrations without receiving these two ownership columns. Reintroduce the
+-- shape under a new forward-only journal entry so both fresh and already
+-- advanced databases converge.
+ALTER TABLE "letters"
+  ADD COLUMN IF NOT EXISTS "extra_content_job_run_id" uuid;
+ALTER TABLE "letters"
+  ADD COLUMN IF NOT EXISTS "extra_content_job_dirty" boolean DEFAULT false NOT NULL;
+
+UPDATE "letters"
+SET "extra_content_job_dirty" = false
+WHERE "extra_content_job_dirty" IS NULL;
+
+ALTER TABLE "letters"
+  ALTER COLUMN "extra_content_job_dirty" SET DEFAULT false;
+ALTER TABLE "letters"
+  ALTER COLUMN "extra_content_job_dirty" SET NOT NULL;
+
+-- A RUNNING row without an owner predates the ownership boundary and cannot be
+-- resumed safely. Return it to the durable queue and clear any later lease
+-- metadata that cannot be bound to a run.
+UPDATE "letters"
+SET "extra_content_job_status" = 'PENDING',
+    "extra_content_job_error" = NULL,
+    "extra_content_job_run_id" = NULL,
+    "extra_content_job_lease_expires_at" = NULL,
+    "extra_content_job_lease_run_id" = NULL,
+    "extra_content_job_claim_kind" = NULL,
+    "extra_content_job_dirty" = false,
+    "updated_at" = clock_timestamp()
+WHERE "extra_content_job_status" = 'RUNNING'
+  AND "extra_content_job_run_id" IS NULL;
+
+-- Normalize any partial legacy ownership tuple before validating the canonical
+-- constraints. Current valid RUNNING attempts retain their owner and dirty bit.
+UPDATE "letters"
+SET "extra_content_job_run_id" = NULL,
+    "extra_content_job_lease_expires_at" = NULL,
+    "extra_content_job_lease_run_id" = NULL,
+    "extra_content_job_claim_kind" = NULL,
+    "extra_content_job_dirty" = false,
+    "updated_at" = clock_timestamp()
+WHERE "extra_content_job_status" <> 'RUNNING'
+  AND (
+    "extra_content_job_run_id" IS NOT NULL
+    OR "extra_content_job_dirty"
+    OR "extra_content_job_lease_expires_at" IS NOT NULL
+    OR "extra_content_job_lease_run_id" IS NOT NULL
+    OR "extra_content_job_claim_kind" IS NOT NULL
+  );
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'extra_content_job_run_id_matches_running'
+      AND conrelid = 'public.letters'::regclass
+  ) THEN
+    ALTER TABLE "letters"
+      ADD CONSTRAINT "extra_content_job_run_id_matches_running"
+      CHECK (
+        ("extra_content_job_status" = 'RUNNING')
+        = ("extra_content_job_run_id" IS NOT NULL)
+      ) NOT VALID;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'extra_content_job_dirty_requires_running'
+      AND conrelid = 'public.letters'::regclass
+  ) THEN
+    ALTER TABLE "letters"
+      ADD CONSTRAINT "extra_content_job_dirty_requires_running"
+      CHECK (
+        NOT "extra_content_job_dirty"
+        OR "extra_content_job_status" = 'RUNNING'
+      ) NOT VALID;
+  END IF;
+END
+$$;
+
+ALTER TABLE "letters"
+  VALIDATE CONSTRAINT "extra_content_job_run_id_matches_running";
+ALTER TABLE "letters"
+  VALIDATE CONSTRAINT "extra_content_job_dirty_requires_running";

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1777372800000,
       "tag": "0055_add_transcript_confirmation_intent",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1777459200000,
+      "tag": "0056_repair_extra_content_job_ownership",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/services/__tests__/bulk-operations.test.ts
+++ b/backend/src/services/__tests__/bulk-operations.test.ts
@@ -37,6 +37,7 @@ const {
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...clauses: unknown[]) => ({ kind: 'and', clauses })),
   eq: vi.fn((field: unknown, value: unknown) => ({ kind: 'eq', field, value })),
+  exists: vi.fn((query: unknown) => ({ kind: 'exists', query })),
   inArray: vi.fn((field: unknown, values: unknown[]) => ({ kind: 'inArray', field, values })),
   isNull: vi.fn((field: unknown) => ({ kind: 'isNull', field })),
   isNotNull: vi.fn((field: unknown) => ({ kind: 'isNotNull', field })),
@@ -65,6 +66,14 @@ vi.mock('../../db/index.js', () => {
   return {
     db: {
       query: { letters: { findMany: findManyMock, findFirst: findFirstMock } },
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            kind: 'subquery',
+            condition,
+          })),
+        })),
+      })),
       update: dbUpdateMock,
       transaction: dbTransactionMock,
     },
@@ -261,7 +270,7 @@ describe('bulk transcription ownership', () => {
             },
             { kind: 'ne', field: 'letters.metadataStatus', value: 'RUNNING' },
             { kind: 'ne', field: 'letters.entityExtractionStatus', value: 'RUNNING' },
-            expect.objectContaining({ kind: 'sql' }),
+            expect.objectContaining({ kind: 'exists' }),
             { kind: 'eq', field: 'letters.primarySourceRevision', value: 7 },
             { kind: 'eq', field: 'letters.transcriptionStatus', value: 'PENDING' },
             { kind: 'eq', field: 'letters.workflow', value: 'UPLOADED' },

--- a/backend/src/services/__tests__/letters.test.ts
+++ b/backend/src/services/__tests__/letters.test.ts
@@ -18,6 +18,7 @@ const {
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ kind: 'eq', field, value })),
+  exists: vi.fn((query: unknown) => ({ kind: 'exists', query })),
   ne: vi.fn((field: unknown, value: unknown) => ({ kind: 'ne', field, value })),
   and: vi.fn((...clauses: unknown[]) => ({ kind: 'and', clauses })),
   gt: vi.fn((field: unknown, value: unknown) => ({ kind: 'gt', field, value })),
@@ -52,6 +53,14 @@ vi.mock('../../db/index.js', () => {
           findMany: findManyMock,
         },
       },
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            kind: 'subquery',
+            condition,
+          })),
+        })),
+      })),
       update: dbUpdateMock,
     },
     letters: {
@@ -243,17 +252,7 @@ describe('letters service', () => {
         },
         { kind: 'ne', field: 'letters.metadataStatus', value: 'RUNNING' },
         { kind: 'ne', field: 'letters.entityExtractionStatus', value: 'RUNNING' },
-        expect.objectContaining({
-          kind: 'sql',
-          strings: expect.arrayContaining([
-            expect.stringContaining('EXISTS'),
-          ]),
-          values: [
-            { letterId: 'letterPages.letterId' },
-            'letterPages.letterId',
-            'letters.id',
-          ],
-        }),
+        expect.objectContaining({ kind: 'exists' }),
         { kind: 'ne', field: 'letters.transcriptionStatus', value: 'RUNNING' },
       ],
     });

--- a/backend/src/services/__tests__/process-eligibility.test.ts
+++ b/backend/src/services/__tests__/process-eligibility.test.ts
@@ -8,6 +8,7 @@ vi.mock('drizzle-orm', () => ({
     values,
   })),
   ne: vi.fn((field: unknown, value: unknown) => ({ kind: 'ne', field, value })),
+  exists: vi.fn((query: unknown) => ({ kind: 'exists', query })),
   isNotNull: vi.fn((field: unknown) => ({ kind: 'isNotNull', field })),
   isNull: vi.fn((field: unknown) => ({ kind: 'isNull', field })),
   and: vi.fn((...clauses: unknown[]) => ({ kind: 'and', clauses })),
@@ -20,6 +21,16 @@ vi.mock('drizzle-orm', () => ({
 }));
 
 vi.mock('../../db/index.js', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((condition: unknown) => ({
+          kind: 'subquery',
+          condition,
+        })),
+      })),
+    })),
+  },
   letters: {
     type: 'letters.type',
     workflow: 'letters.workflow',
@@ -89,10 +100,7 @@ describe('durable processing eligibility', () => {
       },
       { kind: 'ne', field: 'letters.metadataStatus', value: 'RUNNING' },
       { kind: 'ne', field: 'letters.entityExtractionStatus', value: 'RUNNING' },
-      expect.objectContaining({
-        kind: 'sql',
-        strings: expect.arrayContaining([expect.stringContaining('EXISTS')]),
-      }),
+      expect.objectContaining({ kind: 'exists' }),
       { kind: 'eq', field: 'letters.workflow', value: 'UPLOADED' },
       { kind: 'eq', field: 'letters.transcriptionStatus', value: 'PENDING' },
       { kind: 'isNull', field: 'letters.transcriptionRunId' },

--- a/backend/src/services/__tests__/processing-eligibility-sql.test.ts
+++ b/backend/src/services/__tests__/processing-eligibility-sql.test.ts
@@ -1,0 +1,20 @@
+import { and } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { db } from '../../db/index.js';
+import { queuedTranscriptionConditions } from '../processing-eligibility.js';
+
+describe('processing eligibility SQL', () => {
+  it('keeps the page prerequisite correlated to letter_pages in relational queries', () => {
+    const query = db.query.letters.findMany({
+      where: and(...queuedTranscriptionConditions()),
+      columns: { id: true },
+    });
+    const { sql } = query.toSQL();
+
+    expect(sql).toMatch(/from "letter_pages"/i);
+    expect(sql).toMatch(
+      /where "letter_pages"\."letter_id" = "letters"\."id"/i,
+    );
+    expect(sql).not.toContain('"letters"."letter_id"');
+  });
+});

--- a/backend/src/services/__tests__/processing-queue.test.ts
+++ b/backend/src/services/__tests__/processing-queue.test.ts
@@ -44,6 +44,7 @@ const {
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ kind: 'eq', field, value })),
+  exists: vi.fn((query: unknown) => ({ kind: 'exists', query })),
   ne: vi.fn((field: unknown, value: unknown) => ({ kind: 'ne', field, value })),
   and: vi.fn((...clauses: unknown[]) => ({ kind: 'and', clauses })),
   isNotNull: vi.fn((field: unknown) => ({ kind: 'isNotNull', field })),
@@ -77,6 +78,14 @@ vi.mock('../../db/index.js', () => {
           findMany: findManyLettersMock,
         },
       },
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            kind: 'subquery',
+            condition,
+          })),
+        })),
+      })),
       update: dbUpdateMock,
     },
     letters: {
@@ -842,17 +851,7 @@ describe('processing queue service', () => {
         },
         { kind: 'ne', field: 'letters.metadataStatus', value: 'RUNNING' },
         { kind: 'ne', field: 'letters.entityExtractionStatus', value: 'RUNNING' },
-        expect.objectContaining({
-          kind: 'sql',
-          strings: expect.arrayContaining([
-            expect.stringContaining('EXISTS'),
-          ]),
-          values: [
-            { letterId: 'letterPages.letterId' },
-            'letterPages.letterId',
-            'letters.id',
-          ],
-        }),
+        expect.objectContaining({ kind: 'exists' }),
         {
           kind: 'sql',
           strings: ["date_trunc('milliseconds', ", ') = ', '::timestamptz'],

--- a/backend/src/services/processing-eligibility.ts
+++ b/backend/src/services/processing-eligibility.ts
@@ -1,6 +1,7 @@
 import {
   and,
   eq,
+  exists,
   inArray,
   isNotNull,
   isNull,
@@ -9,7 +10,7 @@ import {
   sql,
   type SQL,
 } from 'drizzle-orm';
-import { letterPages, letters } from '../db/index.js';
+import { db, letterPages, letters } from '../db/index.js';
 import {
   isTranscribableType,
   TRANSCRIBABLE_TYPES,
@@ -94,11 +95,11 @@ export function transcriptionPrerequisiteConditions(): SQL[] {
     inArray(letters.type, [...TRANSCRIBABLE_TYPES]),
     ne(letters.metadataStatus, 'RUNNING'),
     ne(letters.entityExtractionStatus, 'RUNNING'),
-    sql`EXISTS (
-      SELECT 1
-      FROM ${letterPages}
-      WHERE ${letterPages.letterId} = ${letters.id}
-    )`,
+    exists(
+      db.select({ one: sql`1` })
+        .from(letterPages)
+        .where(eq(letterPages.letterId, letters.id)),
+    ),
   ];
 }
 


### PR DESCRIPTION
## Summary

Fixes two backend startup failures discovered immediately after PR #54 was merged and the local stack was restarted.

- Adds forward-only migration `0056` to repair databases that skipped the current `0045_add_extra_content_job_ownership` because an older branch had already used the same migration timestamp for a different migration.
- Restores and validates the extra-content run/dirty ownership shape without inventing owners for legacy `RUNNING` rows.
- Replaces the page-backed transcription prerequisite's raw interpolated column with a typed nested `EXISTS` query.
- Prevents Drizzle's relational alias mapper from generating the invalid predicate `"letters"."letter_id" = "letters"."id"`.
- Adds generated-SQL and migration-lineage regression coverage.

## Root causes

Three historical branches reused journal index/timestamp 45 for different migrations. Drizzle's PostgreSQL migrator advances by timestamp rather than comparing hashes, so an affected database could apply later migrations while permanently skipping the current extra-content ownership columns.

Separately, Drizzle rewrites every interpolated column inside raw SQL used by a relational query to the outer relation alias. The prior `EXISTS` predicate therefore referenced a nonexistent `letters.letter_id` column at runtime even though unit tests passed against uncompiled predicate chunks.

## Validation

- [x] Backend: 112 test files, 1,178 tests passed
- [x] Backend typecheck passed
- [x] Fresh/legacy Postgres migration harness passed
- [x] The forward-only repair applied successfully to the affected local database
- [x] API `/health` returns 200
- [x] Background worker successfully claims and completes queued jobs
- [x] Frontend returns 200 at `http://localhost:5174`
- [x] `git diff --check` passed
