### PR TITLE
Add safe automatic production releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -62,10 +62,10 @@ jobs:
       E2E_API_BASE_URL: http://localhost:3002
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload mocked Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-mocked-report
           path: e2e/playwright-report
@@ -123,10 +123,10 @@ jobs:
       CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-smoke-report
           path: e2e/playwright-report
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload backend structured logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backend-structured-logs-smoke
           path: backend/logs
@@ -249,10 +249,10 @@ jobs:
       CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-full-report
           path: e2e/playwright-report
@@ -333,7 +333,7 @@ jobs:
 
       - name: Upload backend structured logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backend-structured-logs-full
           path: backend/logs
@@ -346,3 +346,124 @@ jobs:
       - name: Dump frontend logs on failure
         if: failure()
         run: cat /tmp/frontend.log || true
+
+  release:
+    name: Production Release
+    runs-on: ubuntu-latest
+    needs:
+      - quality
+      - e2e-mocked
+      - e2e-smoke
+    if: >-
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && vars.AUTOMATIC_RELEASES_ENABLED == 'true'
+    concurrency:
+      group: letter-archive-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    environment: production
+    steps:
+      - name: Checkout exact release commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine release scope
+        id: scope
+        env:
+          HEAD_REVISION: ${{ github.sha }}
+        run: |
+          backend_revision="$(
+            curl --connect-timeout 5 --max-time 15 -fsS \
+              https://api.voicesthatremain.com/health \
+              | jq -r '.releaseSha // empty'
+          )" || backend_revision=unavailable
+          frontend_revision="$(
+            curl --connect-timeout 5 --max-time 15 -fsS \
+              https://voicesthatremain.com/version.json \
+              | jq -r '.releaseSha // empty'
+          )" || frontend_revision=unavailable
+          sha_pattern='^[0-9a-f]{40}$'
+          if [[ ! "$backend_revision" =~ $sha_pattern ]]; then
+            backend_revision=unavailable
+          fi
+          if [[ ! "$frontend_revision" =~ $sha_pattern ]]; then
+            frontend_revision=unavailable
+          fi
+          scope="$(
+            bash deploy/cloudrun/select-release-scope.sh \
+              "$backend_revision" "$frontend_revision" "$HEAD_REVISION"
+          )"
+          case "$scope" in
+            none|stale|frontend|full) ;;
+            *)
+              echo "Unexpected release scope: $scope" >&2
+              exit 1
+              ;;
+          esac
+          {
+            printf 'scope=%s\n' "$scope"
+            printf 'backend_revision=%s\n' "$backend_revision"
+            printf 'frontend_revision=%s\n' "$frontend_revision"
+          } >> "$GITHUB_OUTPUT"
+          printf 'Release scope: %s\n' "$scope"
+
+      - name: Authenticate to Google Cloud
+        if: >-
+          steps.scope.outputs.scope != 'none'
+          && steps.scope.outputs.scope != 'stale'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: letter-archive-485110
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_RELEASE_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud CLI
+        if: >-
+          steps.scope.outputs.scope != 'none'
+          && steps.scope.outputs.scope != 'stale'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Start exact-SHA Cloud Build release
+        if: >-
+          steps.scope.outputs.scope != 'none'
+          && steps.scope.outputs.scope != 'stale'
+        env:
+          RELEASE_SCOPE: ${{ steps.scope.outputs.scope }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$RELEASE_SCOPE" == "frontend" ]]; then
+            release_config=cloudbuild.frontend-release.yaml
+          else
+            release_config=cloudbuild.release.yaml
+          fi
+
+          gcloud builds submit \
+            https://github.com/MLGalusha/letter-archive.git \
+            --project=letter-archive-485110 \
+            --region=us-east1 \
+            --git-source-revision="$RELEASE_SHA" \
+            --service-account=projects/letter-archive-485110/serviceAccounts/letter-archive-build@letter-archive-485110.iam.gserviceaccount.com \
+            --config="$release_config" \
+            --substitutions="_TAG=$RELEASE_SHA"
+
+      - name: Record release summary
+        if: always()
+        env:
+          RELEASE_SCOPE: ${{ steps.scope.outputs.scope }}
+          RELEASE_SHA: ${{ github.sha }}
+          PREVIOUS_BACKEND_REVISION: ${{ steps.scope.outputs.backend_revision }}
+          PREVIOUS_FRONTEND_REVISION: ${{ steps.scope.outputs.frontend_revision }}
+        run: |
+          {
+            echo "### Production release"
+            echo
+            echo "- Commit: \`$RELEASE_SHA\`"
+            echo "- Scope: \`${RELEASE_SCOPE:-unknown}\`"
+            echo "- Previous backend: \`${PREVIOUS_BACKEND_REVISION:-unknown}\`"
+            echo "- Previous frontend: \`${PREVIOUS_FRONTEND_REVISION:-unknown}\`"
+            echo "- Project: \`letter-archive-485110\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/backend/src/cli/migrate.ts
+++ b/backend/src/cli/migrate.ts
@@ -1,13 +1,106 @@
 import 'dotenv/config';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
-import { db } from '../db/index.js';
+import { db, sql } from '../db/index.js';
+import {
+  assertMigrationReleaseAllowed,
+  type AppliedMigrationEntry,
+  type MigrationJournalEntry,
+  type MigrationReleaseMode,
+} from '../db/migration-release-policy.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(__dirname, '../../src/db/migrations');
 
+async function appliedMigrationLedger(): Promise<AppliedMigrationEntry[]> {
+  try {
+    const rows = await sql<{
+      createdAt: string;
+      hash: string;
+    }[]>`
+      SELECT
+        hash,
+        created_at::text AS "createdAt"
+      FROM drizzle.__drizzle_migrations
+      ORDER BY created_at ASC, id ASC
+    `;
+    return rows.map(({ createdAt, hash }, position) => {
+      const parsedCreatedAt = Number(createdAt);
+      if (!Number.isSafeInteger(parsedCreatedAt) || parsedCreatedAt < 0) {
+        throw new Error(
+          `Applied migration timestamp is invalid at position ${position}`,
+        );
+      }
+      return {
+        createdAt: parsedCreatedAt,
+        hash,
+      };
+    });
+  } catch (error) {
+    if (
+      typeof error === 'object'
+      && error !== null
+      && 'code' in error
+      && error.code === '42P01'
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function migrationJournal(): Promise<MigrationJournalEntry[]> {
+  const source = await readFile(
+    path.join(migrationsFolder, 'meta', '_journal.json'),
+    'utf8',
+  );
+  const parsed = JSON.parse(source) as {
+    entries?: Omit<MigrationJournalEntry, 'hash'>[];
+  };
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error('Migration journal does not contain an entries array');
+  }
+
+  return Promise.all(parsed.entries.map(async (entry) => {
+    if (typeof entry.tag !== 'string' || entry.tag.length === 0) {
+      throw new Error('Migration journal contains an invalid tag');
+    }
+    const migrationSql = await readFile(
+      path.join(migrationsFolder, `${entry.tag}.sql`),
+      'utf8',
+    );
+    return {
+      ...entry,
+      hash: createHash('sha256').update(migrationSql).digest('hex'),
+    };
+  }));
+}
+
 async function main(): Promise<void> {
+  const mode = process.env.MIGRATION_RELEASE_MODE;
+  if (mode !== 'automatic' && mode !== 'maintenance') {
+    throw new Error(
+      'MIGRATION_RELEASE_MODE must be automatic or maintenance',
+    );
+  }
+
+  const [journal, appliedMigrations] = await Promise.all([
+    migrationJournal(),
+    appliedMigrationLedger(),
+  ]);
+  const pending = assertMigrationReleaseAllowed({
+    journal,
+    appliedMigrations,
+    mode: mode as MigrationReleaseMode,
+  });
+
+  console.log(
+    `Migration release policy accepted ${pending.length} pending migration(s) `
+    + `in ${mode} mode`,
+  );
   await migrate(db, { migrationsFolder });
   console.log(`Migrations applied from ${migrationsFolder}`);
 }

--- a/backend/src/db/__tests__/migration-release-policy.test.ts
+++ b/backend/src/db/__tests__/migration-release-policy.test.ts
@@ -1,0 +1,162 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  assertMigrationReleaseAllowed,
+  automaticMigrationBaselineTag,
+  migrationReleasePolicies,
+  type AppliedMigrationEntry,
+  type MigrationJournalEntry,
+} from '../migration-release-policy.js';
+
+const migrationsDirectory = join(__dirname, '..', 'migrations');
+const rawJournal = JSON.parse(
+  readFileSync(
+    join(migrationsDirectory, 'meta', '_journal.json'),
+    'utf8',
+  ),
+) as { entries: Omit<MigrationJournalEntry, 'hash'>[] };
+const journal: MigrationJournalEntry[] = rawJournal.entries.map((entry) => ({
+  ...entry,
+  hash: createHash('sha256')
+    .update(readFileSync(join(migrationsDirectory, `${entry.tag}.sql`), 'utf8'))
+    .digest('hex'),
+}));
+const baselineIndex = journal.findIndex(
+  ({ tag }) => tag === automaticMigrationBaselineTag,
+);
+const maintenanceStartIndex = journal.findIndex(
+  ({ tag }) => tag === '0054_add_page_source_revisions',
+);
+
+function appliedPrefix(count: number): AppliedMigrationEntry[] {
+  return journal.slice(0, count).map(({ hash, when }) => ({
+    createdAt: when,
+    hash,
+  }));
+}
+
+describe('migration release policy', () => {
+  it('requires an explicit policy for every post-baseline migration', () => {
+    expect(baselineIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      journal
+        .slice(baselineIndex + 1)
+        .filter(({ tag }) => migrationReleasePolicies[tag] === undefined)
+        .map(({ tag }) => tag),
+    ).toEqual([]);
+  });
+
+  it('blocks automatic migration before the maintenance baseline', () => {
+    expect(() => assertMigrationReleaseAllowed({
+      journal,
+      appliedMigrations: appliedPrefix(maintenanceStartIndex),
+      mode: 'automatic',
+    })).toThrow(/controlled bootstrap deployment/);
+  });
+
+  it('allows the controlled maintenance release to cross the baseline', () => {
+    expect(assertMigrationReleaseAllowed({
+      journal,
+      appliedMigrations: appliedPrefix(maintenanceStartIndex),
+      mode: 'maintenance',
+    }).map(({ tag }) => tag)).toEqual([
+      '0054_add_page_source_revisions',
+      '0055_add_transcript_confirmation_intent',
+      '0056_repair_extra_content_job_ownership',
+    ]);
+  });
+
+  it('allows an automatic release with no pending migrations after baseline', () => {
+    expect(assertMigrationReleaseAllowed({
+      journal,
+      appliedMigrations: appliedPrefix(journal.length),
+      mode: 'automatic',
+    })).toEqual([]);
+  });
+
+  it('fails closed when a future migration lacks an automatic policy', () => {
+    const last = journal.at(-1);
+    if (!last) throw new Error('Expected a nonempty migration journal');
+    expect(() => assertMigrationReleaseAllowed({
+      journal: [
+        ...journal,
+        {
+          idx: last.idx + 1,
+          when: last.when + 86_400_000,
+          tag: '0057_unclassified',
+          hash: 'a'.repeat(64),
+        },
+      ],
+      appliedMigrations: appliedPrefix(journal.length),
+      mode: 'automatic',
+    })).toThrow(/0057_unclassified/);
+  });
+
+  it('requires the exact baseline record instead of accepting the same row count', () => {
+    const malformed = appliedPrefix(baselineIndex + 1);
+    malformed[baselineIndex] = malformed[baselineIndex - 1];
+
+    expect(() => assertMigrationReleaseAllowed({
+      journal,
+      appliedMigrations: malformed,
+      mode: 'automatic',
+    })).toThrow(/ledger diverges/);
+  });
+
+  it.each([
+    {
+      name: 'missing applied row',
+      mutate: (applied: AppliedMigrationEntry[]) => {
+        applied.splice(10, 1);
+        return applied;
+      },
+    },
+    {
+      name: 'out-of-order applied rows',
+      mutate: (applied: AppliedMigrationEntry[]) => {
+        [applied[10], applied[11]] = [applied[11], applied[10]];
+        return applied;
+      },
+    },
+    {
+      name: 'wrong applied hash',
+      mutate: (applied: AppliedMigrationEntry[]) => {
+        applied[10] = {
+          ...applied[10],
+          hash: 'f'.repeat(64),
+        };
+        return applied;
+      },
+    },
+  ])('rejects $name', ({ mutate }) => {
+    expect(() => assertMigrationReleaseAllowed({
+      journal,
+      appliedMigrations: mutate(appliedPrefix(journal.length)),
+      mode: 'maintenance',
+    })).toThrow(/ledger diverges/);
+  });
+
+  it('rejects non-increasing journal indexes', () => {
+    const malformed = journal.map((entry) => ({ ...entry }));
+    malformed[11].idx = malformed[10].idx;
+
+    expect(() => assertMigrationReleaseAllowed({
+      journal: malformed,
+      appliedMigrations: [],
+      mode: 'maintenance',
+    })).toThrow(/indexes must be strictly increasing/);
+  });
+
+  it('rejects non-increasing journal timestamps', () => {
+    const malformed = journal.map((entry) => ({ ...entry }));
+    malformed[11].when = malformed[10].when;
+
+    expect(() => assertMigrationReleaseAllowed({
+      journal: malformed,
+      appliedMigrations: [],
+      mode: 'maintenance',
+    })).toThrow(/timestamps must be strictly increasing/);
+  });
+});

--- a/backend/src/db/migration-release-policy.ts
+++ b/backend/src/db/migration-release-policy.ts
@@ -1,0 +1,150 @@
+export type MigrationReleaseMode = 'automatic' | 'maintenance';
+
+export interface MigrationJournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+  hash: string;
+}
+
+export interface AppliedMigrationEntry {
+  createdAt: number;
+  hash: string;
+}
+
+/**
+ * Production must cross this baseline through the one-time maintenance release
+ * before ordinary rolling deployments may apply migrations automatically.
+ */
+export const automaticMigrationBaselineTag =
+  '0056_repair_extra_content_job_ownership';
+
+/**
+ * Every migration after the automatic baseline must be classified explicitly.
+ * "automatic" means expand-only and safe while the previous application
+ * revision is still serving. "maintenance" requires a quiesced deployment.
+ */
+export const migrationReleasePolicies: Readonly<
+  Record<string, MigrationReleaseMode>
+> = Object.freeze({});
+
+function assertValidJournal(
+  journal: readonly MigrationJournalEntry[],
+): void {
+  for (const [position, entry] of journal.entries()) {
+    if (!Number.isInteger(entry.idx) || entry.idx < 0) {
+      throw new Error(
+        `Migration journal idx must be a nonnegative integer at position ${position}`,
+      );
+    }
+    if (
+      position > 0
+      && entry.idx <= journal[position - 1].idx
+    ) {
+      throw new Error('Migration journal indexes must be strictly increasing');
+    }
+    if (!Number.isSafeInteger(entry.when) || entry.when < 0) {
+      throw new Error(
+        `Migration journal timestamp must be a nonnegative safe integer: ${entry.tag}`,
+      );
+    }
+    if (
+      position > 0
+      && entry.when <= journal[position - 1].when
+    ) {
+      throw new Error('Migration journal timestamps must be strictly increasing');
+    }
+    if (typeof entry.tag !== 'string' || entry.tag.length === 0) {
+      throw new Error(`Migration journal tag is invalid at position ${position}`);
+    }
+    if (!/^[0-9a-f]{64}$/.test(entry.hash)) {
+      throw new Error(`Migration journal hash is invalid: ${entry.tag}`);
+    }
+  }
+}
+
+export function pendingMigrationEntries(
+  journal: readonly MigrationJournalEntry[],
+  appliedMigrations: readonly AppliedMigrationEntry[],
+): readonly MigrationJournalEntry[] {
+  assertValidJournal(journal);
+
+  if (appliedMigrations.length > journal.length) {
+    throw new Error(
+      `Database reports ${appliedMigrations.length} migrations, but the image contains only `
+      + `${journal.length}`,
+    );
+  }
+
+  for (const [position, applied] of appliedMigrations.entries()) {
+    if (
+      !Number.isSafeInteger(applied.createdAt)
+      || applied.createdAt < 0
+      || !/^[0-9a-f]{64}$/.test(applied.hash)
+    ) {
+      throw new Error(
+        `Applied migration ledger entry is invalid at position ${position}`,
+      );
+    }
+
+    const expected = journal[position];
+    if (
+      applied.createdAt !== expected.when
+      || applied.hash !== expected.hash
+    ) {
+      throw new Error(
+        `Applied migration ledger diverges at position ${position}; expected `
+        + `${expected.tag} (${expected.when}, ${expected.hash}), found `
+        + `(${applied.createdAt}, ${applied.hash})`,
+      );
+    }
+  }
+
+  return journal.slice(appliedMigrations.length);
+}
+
+export function assertMigrationReleaseAllowed(input: {
+  journal: readonly MigrationJournalEntry[];
+  appliedMigrations: readonly AppliedMigrationEntry[];
+  mode: MigrationReleaseMode;
+}): readonly MigrationJournalEntry[] {
+  const { journal, appliedMigrations, mode } = input;
+  const baselineIndex = journal.findIndex(
+    ({ tag }) => tag === automaticMigrationBaselineTag,
+  );
+
+  if (baselineIndex < 0) {
+    throw new Error(
+      `Automatic migration baseline is missing from the journal: `
+      + automaticMigrationBaselineTag,
+    );
+  }
+
+  const pending = pendingMigrationEntries(journal, appliedMigrations);
+  if (mode === 'maintenance') return pending;
+
+  const baseline = journal[baselineIndex];
+  const appliedBaseline = appliedMigrations[baselineIndex];
+  if (
+    !appliedBaseline
+    || appliedBaseline.createdAt !== baseline.when
+    || appliedBaseline.hash !== baseline.hash
+  ) {
+    throw new Error(
+      'Production has not crossed the maintenance migration baseline; '
+      + 'run the controlled bootstrap deployment',
+    );
+  }
+
+  const unsafe = pending.filter(
+    ({ tag }) => migrationReleasePolicies[tag] !== 'automatic',
+  );
+  if (unsafe.length > 0) {
+    throw new Error(
+      'Automatic deployment refused unclassified or maintenance migrations: '
+      + unsafe.map(({ tag }) => tag).join(', '),
+    );
+  }
+
+  return pending;
+}

--- a/backend/src/routes/__tests__/health.integration.test.ts
+++ b/backend/src/routes/__tests__/health.integration.test.ts
@@ -10,7 +10,10 @@ describe('health route integration', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.body).toEqual({ ok: true });
+    expect(response.body).toEqual({
+      ok: true,
+      releaseSha: 'development',
+    });
     expect(response.headers['x-request-id']).toMatch(/^[0-9a-f-]{36}$/i);
   });
 });

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -6,7 +6,10 @@ const router = Router();
 // Liveness probe — always returns ok if the process is running.
 // Used by Cloud Run startupProbe / livenessProbe.
 router.get('/health', (_req, res) => {
-  res.json({ ok: true });
+  res.json({
+    ok: true,
+    releaseSha: process.env.RELEASE_SHA ?? 'development',
+  });
 });
 
 // Readiness probe — validates database connectivity.

--- a/backend/src/services/__tests__/deployment-manifest-renderer.test.ts
+++ b/backend/src/services/__tests__/deployment-manifest-renderer.test.ts
@@ -1,0 +1,438 @@
+import { execFileSync } from 'node:child_process';
+import {
+  appendFileSync,
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repositoryRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+const manifestTemplateDirectory = path.join(
+  repositoryRoot,
+  'deploy/cloudrun',
+);
+const rendererPath = path.join(
+  manifestTemplateDirectory,
+  'render-manifests.sh',
+);
+const candidateRendererPath = path.join(
+  manifestTemplateDirectory,
+  'prepare-candidate-manifest.sh',
+);
+
+const manifestNames = [
+  'backend-backfill-dimensions-job.yaml',
+  'backend-migrate-job.yaml',
+  'backend-service.yaml',
+  'backend-worker-job.yaml',
+  'frontend-service.yaml',
+] as const;
+
+const validRenderEnvironment = {
+  LETTER_ARCHIVE_PROJECT_ID: 'letter-archive-test',
+  LETTER_ARCHIVE_REGION: 'us-east1',
+  LETTER_ARCHIVE_CLOUD_SQL_INSTANCE: 'letter-archive-db',
+  LETTER_ARCHIVE_ARCHIVE_BUCKET: 'letter-archive-test-archive',
+  LETTER_ARCHIVE_DOMAIN: 'example.test',
+  LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT:
+    'letter-archive-backend@letter-archive-test.iam.gserviceaccount.com',
+  LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT:
+    'letter-archive-frontend@letter-archive-test.iam.gserviceaccount.com',
+  LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT:
+    'letter-archive-worker@letter-archive-test.iam.gserviceaccount.com',
+  LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT:
+    'letter-archive-migrate@letter-archive-test.iam.gserviceaccount.com',
+  LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT:
+    'letter-archive-backfill@letter-archive-test.iam.gserviceaccount.com',
+  LETTER_ARCHIVE_MIGRATION_RELEASE_MODE: 'automatic',
+  LETTER_ARCHIVE_RELEASE_SHA:
+    '0123456789abcdef0123456789abcdef01234567',
+  LETTER_ARCHIVE_BACKEND_IMAGE:
+    'us-east1-docker.pkg.dev/letter-archive-test/archive/backend:abc123',
+  LETTER_ARCHIVE_FRONTEND_IMAGE:
+    'us-east1-docker.pkg.dev/letter-archive-test/archive/frontend:abc123',
+};
+
+const temporaryDirectories: string[] = [];
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function executeRenderer(
+  templateDirectory: string,
+  outputDirectory: string,
+  environment: NodeJS.ProcessEnv = validRenderEnvironment,
+): void {
+  execFileSync(
+    'bash',
+    [rendererPath, templateDirectory, outputDirectory],
+    {
+      cwd: repositoryRoot,
+      env: {
+        PATH: process.env.PATH,
+        ...environment,
+      },
+      stdio: 'pipe',
+    },
+  );
+}
+
+function renderManifestTemplates(): Map<string, string> {
+  const temporaryRoot = createTemporaryDirectory(
+    'letter-archive-cloudrun-render-',
+  );
+  const outputDirectory = path.join(temporaryRoot, 'rendered');
+
+  executeRenderer(manifestTemplateDirectory, outputDirectory);
+
+  return new Map(
+    readdirSync(outputDirectory)
+      .filter((file) => file.endsWith('.yaml'))
+      .map((file) => [
+        file,
+        readFileSync(path.join(outputDirectory, file), 'utf8'),
+      ]),
+  );
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('Cloud Run deployment manifest renderer', () => {
+  it('renders every manifest field without mutating environment variable names', () => {
+    const manifests = renderManifestTemplates();
+    const combinedSource = [...manifests.values()].join('\n');
+    const backendImage =
+      'us-east1-docker.pkg.dev/letter-archive-test/archive/backend:abc123';
+    const frontendImage =
+      'us-east1-docker.pkg.dev/letter-archive-test/archive/frontend:abc123';
+    const cloudSql =
+      'letter-archive-test:us-east1:letter-archive-db';
+
+    expect([...manifests.keys()].sort()).toEqual([...manifestNames].sort());
+    expect(combinedSource).not.toMatch(/__[A-Z][A-Z0-9_]*__/);
+    expect(combinedSource).not.toMatch(
+      /(^|[^A-Z0-9_])(PROJECT_NUMBER|PROJECT_ID|REGION|CLOUD_SQL_INSTANCE|ARCHIVE_BUCKET|YOUR_DOMAIN|SERVICE_ACCOUNT_EMAIL|BACKEND_IMAGE|FRONTEND_IMAGE)([^A-Z0-9_]|$)/m,
+    );
+    expect(combinedSource).not.toContain('CLOUD_RUN_us-east1');
+
+    for (const file of manifestNames) {
+      const manifest = manifests.get(file);
+      expect(manifest, file).toContain('namespace: letter-archive-test');
+      expect(manifest, file).toContain(
+        'cloud.googleapis.com/location: us-east1',
+      );
+    }
+
+    const serviceAccounts = new Map([
+      [
+        'backend-backfill-dimensions-job.yaml',
+        'letter-archive-backfill',
+      ],
+      ['backend-migrate-job.yaml', 'letter-archive-migrate'],
+      ['backend-service.yaml', 'letter-archive-backend'],
+      ['backend-worker-job.yaml', 'letter-archive-worker'],
+      ['frontend-service.yaml', 'letter-archive-frontend'],
+    ]);
+    for (const [file, account] of serviceAccounts) {
+      expect(manifests.get(file), file).toContain(
+        `serviceAccountName: ${account}`
+        + '@letter-archive-test.iam.gserviceaccount.com',
+      );
+    }
+
+    for (const file of [
+      'backend-backfill-dimensions-job.yaml',
+      'backend-migrate-job.yaml',
+      'backend-service.yaml',
+      'backend-worker-job.yaml',
+    ]) {
+      const manifest = manifests.get(file);
+      expect(manifest, file).toContain(`image: ${backendImage}`);
+      expect(manifest, file).toContain(
+        `run.googleapis.com/cloudsql-instances: ${cloudSql}`,
+      );
+    }
+
+    const databaseSecrets = new Map([
+      ['backend-backfill-dimensions-job.yaml', 'database-url-backfill'],
+      ['backend-migrate-job.yaml', 'database-url-migrate'],
+      ['backend-service.yaml', 'database-url-api'],
+      ['backend-worker-job.yaml', 'database-url-worker'],
+    ]);
+    for (const [file, secret] of databaseSecrets) {
+      const manifest = manifests.get(file);
+      expect(manifest, file).toContain(`name: ${secret}`);
+      expect(manifest, file).not.toMatch(/\bname: database-url\s/);
+      for (const otherSecret of databaseSecrets.values()) {
+        if (otherSecret !== secret) {
+          expect(manifest, file).not.toContain(`name: ${otherSecret}`);
+        }
+      }
+    }
+
+    for (const file of [
+      'backend-backfill-dimensions-job.yaml',
+      'backend-service.yaml',
+      'backend-worker-job.yaml',
+    ]) {
+      expect(manifests.get(file), file).toContain(
+        'bucketName: letter-archive-test-archive',
+      );
+    }
+
+    for (const file of [
+      'backend-service.yaml',
+      'backend-worker-job.yaml',
+    ]) {
+      expect(manifests.get(file), file).toMatch(
+        /name: CLOUD_RUN_REGION\s+value: us-east1/,
+      );
+    }
+
+    const backendService = manifests.get('backend-service.yaml');
+    expect(backendService).toContain('kind: Service');
+    expect(backendService).toContain('name: letter-archive-backend');
+    expect(backendService).toContain('value: https://example.test');
+    expect(backendService).toMatch(
+      /name: RELEASE_SHA\s+value: 0123456789abcdef0123456789abcdef01234567/,
+    );
+
+    const frontendService = manifests.get('frontend-service.yaml');
+    expect(frontendService).toContain('kind: Service');
+    expect(frontendService).toContain('name: letter-archive-frontend');
+    expect(frontendService).toContain(`image: ${frontendImage}`);
+    expect(frontendService).not.toContain('cloudsql-instances');
+    expect(frontendService).not.toContain('bucketName:');
+
+    expect(manifests.get('backend-migrate-job.yaml')).not.toContain(
+      'bucketName:',
+    );
+    expect(manifests.get('backend-migrate-job.yaml')).toMatch(
+      /name: MIGRATION_RELEASE_MODE\s+value: automatic/,
+    );
+  });
+
+  it('fails closed when a required render value is missing', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-cloudrun-render-missing-',
+    );
+    const outputDirectory = path.join(temporaryRoot, 'rendered');
+
+    expect(() => executeRenderer(
+      manifestTemplateDirectory,
+      outputDirectory,
+      {
+        LETTER_ARCHIVE_PROJECT_ID: 'letter-archive-test',
+      },
+    )).toThrow();
+    expect(existsSync(outputDirectory)).toBe(false);
+  });
+
+  it('can render only the frontend manifest with frontend-scoped values', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-cloudrun-render-frontend-',
+    );
+    const outputDirectory = path.join(temporaryRoot, 'rendered');
+
+    execFileSync(
+      'bash',
+      [
+        rendererPath,
+        manifestTemplateDirectory,
+        outputDirectory,
+        'frontend-service.yaml',
+      ],
+      {
+        cwd: repositoryRoot,
+        env: {
+          PATH: process.env.PATH,
+          LETTER_ARCHIVE_PROJECT_ID:
+            validRenderEnvironment.LETTER_ARCHIVE_PROJECT_ID,
+          LETTER_ARCHIVE_REGION:
+            validRenderEnvironment.LETTER_ARCHIVE_REGION,
+          LETTER_ARCHIVE_DOMAIN:
+            validRenderEnvironment.LETTER_ARCHIVE_DOMAIN,
+          LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT:
+            validRenderEnvironment.LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT,
+          LETTER_ARCHIVE_FRONTEND_IMAGE:
+            validRenderEnvironment.LETTER_ARCHIVE_FRONTEND_IMAGE,
+        },
+        stdio: 'pipe',
+      },
+    );
+
+    expect(readdirSync(outputDirectory)).toEqual(['frontend-service.yaml']);
+    expect(
+      readFileSync(path.join(outputDirectory, 'frontend-service.yaml'), 'utf8'),
+    ).toContain(validRenderEnvironment.LETTER_ARCHIVE_FRONTEND_IMAGE);
+  });
+
+  it('creates a zero-traffic candidate with the complete service template', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-cloudrun-candidate-',
+    );
+    const renderedDirectory = path.join(temporaryRoot, 'rendered');
+    executeRenderer(manifestTemplateDirectory, renderedDirectory);
+    const source = path.join(renderedDirectory, 'frontend-service.yaml');
+    const candidate = path.join(renderedDirectory, 'frontend-candidate.yaml');
+
+    execFileSync('bash', [candidateRendererPath, source, candidate], {
+      cwd: repositoryRoot,
+      env: {
+        PATH: process.env.PATH,
+        LETTER_ARCHIVE_SERVICE: 'letter-archive-frontend',
+        LETTER_ARCHIVE_PREVIOUS_REVISION:
+          'letter-archive-frontend-r-previous',
+        LETTER_ARCHIVE_CANDIDATE_REVISION:
+          'letter-archive-frontend-r-candidate',
+        LETTER_ARCHIVE_CANDIDATE_TAG: 'c-release-build',
+      },
+      stdio: 'pipe',
+    });
+
+    const candidateSource = readFileSync(candidate, 'utf8');
+    expect(candidateSource).toContain(
+      'name: letter-archive-frontend-r-candidate',
+    );
+    expect(candidateSource).toContain(
+      'revisionName: letter-archive-frontend-r-previous',
+    );
+    expect(candidateSource).toMatch(
+      /revisionName: letter-archive-frontend-r-candidate\s+percent: 0\s+tag: c-release-build/,
+    );
+    expect(candidateSource).not.toContain('latestRevision: true');
+    expect(candidateSource).toContain(
+      validRenderEnvironment.LETTER_ARCHIVE_FRONTEND_IMAGE,
+    );
+    expect(candidateSource).toContain('memory: 256Mi');
+  });
+
+  it('rejects values that could alter shell or YAML structure', () => {
+    for (const unsafeDomain of [
+      'example.test # truncated',
+      'example.test: bad',
+      'example.test\\bad',
+      'example.test\r',
+      'example.test\tbad',
+    ]) {
+      const temporaryRoot = createTemporaryDirectory(
+        'letter-archive-cloudrun-render-unsafe-',
+      );
+      const outputDirectory = path.join(temporaryRoot, 'rendered');
+
+      expect(() => executeRenderer(
+        manifestTemplateDirectory,
+        outputDirectory,
+        {
+          ...validRenderEnvironment,
+          LETTER_ARCHIVE_DOMAIN: unsafeDomain,
+        },
+      ), unsafeDomain).toThrow();
+      expect(existsSync(outputDirectory), unsafeDomain).toBe(false);
+    }
+  });
+
+  it('rejects a rerun without changing existing rendered output', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-cloudrun-render-rerun-',
+    );
+    const outputDirectory = path.join(temporaryRoot, 'rendered');
+
+    executeRenderer(manifestTemplateDirectory, outputDirectory);
+
+    const originalOutput = new Map(manifestNames.map((file) => [
+      file,
+      readFileSync(path.join(outputDirectory, file), 'utf8'),
+    ]));
+
+    expect(() => executeRenderer(
+      manifestTemplateDirectory,
+      outputDirectory,
+      {
+        ...validRenderEnvironment,
+        LETTER_ARCHIVE_PROJECT_ID: 'letter-archive-next',
+        LETTER_ARCHIVE_ARCHIVE_BUCKET: 'letter-archive-next-archive',
+        LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT:
+          'letter-archive-backend@letter-archive-next.iam.gserviceaccount.com',
+        LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT:
+          'letter-archive-frontend@letter-archive-next.iam.gserviceaccount.com',
+        LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT:
+          'letter-archive-worker@letter-archive-next.iam.gserviceaccount.com',
+        LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT:
+          'letter-archive-migrate@letter-archive-next.iam.gserviceaccount.com',
+        LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT:
+          'letter-archive-backfill@letter-archive-next.iam.gserviceaccount.com',
+        LETTER_ARCHIVE_BACKEND_IMAGE:
+          'us-east1-docker.pkg.dev/letter-archive-next/archive/backend:def456',
+        LETTER_ARCHIVE_FRONTEND_IMAGE:
+          'us-east1-docker.pkg.dev/letter-archive-next/archive/frontend:def456',
+      },
+    )).toThrow();
+
+    for (const [file, originalContents] of originalOutput) {
+      expect(
+        readFileSync(path.join(outputDirectory, file), 'utf8'),
+        file,
+      ).toBe(originalContents);
+    }
+    expect(
+      readdirSync(temporaryRoot).filter((entry) => (
+        entry.startsWith('.cloudrun-render.')
+      )),
+    ).toEqual([]);
+  });
+
+  it('leaves every template unchanged after a late validation failure', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-cloudrun-render-atomic-',
+    );
+    const templateCopy = path.join(temporaryRoot, 'templates');
+    const outputDirectory = path.join(temporaryRoot, 'rendered');
+    cpSync(manifestTemplateDirectory, templateCopy, { recursive: true });
+
+    appendFileSync(
+      path.join(templateCopy, 'frontend-service.yaml'),
+      '\n# __UNKNOWN_PLACEHOLDER__\n',
+    );
+
+    const originals = new Map(manifestNames.map((file) => {
+      const absolutePath = path.join(templateCopy, file);
+      return [file, {
+        contents: readFileSync(absolutePath, 'utf8'),
+        mode: statSync(absolutePath).mode,
+      }];
+    }));
+
+    expect(() => executeRenderer(templateCopy, outputDirectory)).toThrow();
+    expect(existsSync(outputDirectory)).toBe(false);
+
+    for (const [file, original] of originals) {
+      const absolutePath = path.join(templateCopy, file);
+      expect(readFileSync(absolutePath, 'utf8'), file).toBe(
+        original.contents,
+      );
+      expect(statSync(absolutePath).mode, file).toBe(original.mode);
+    }
+
+    expect(
+      readdirSync(temporaryRoot).filter((entry) => (
+        entry.startsWith('.cloudrun-render.')
+      )),
+    ).toEqual([]);
+  });
+});

--- a/backend/src/services/__tests__/deployment-release-orchestration.test.ts
+++ b/backend/src/services/__tests__/deployment-release-orchestration.test.ts
@@ -493,6 +493,9 @@ if (args.slice(0, 2).join(' ') === 'storage cp') {
 }
 
 if (args.slice(0, 2).join(' ') === 'storage cat') {
+  if (!args.includes(
+    'gs://test-project-release-lock/production.lock#7',
+  )) process.exit(95);
   process.stdout.write(
     '11111111-1111-1111-1111-111111111111 ' + 'c'.repeat(40),
   );
@@ -550,14 +553,22 @@ process.exit(98);
     const generationRead = calls.findIndex((call) =>
       call.startsWith('gcloud storage objects describe')
     );
+    const versionedPayloadReads = calls.filter((call) =>
+      call.startsWith('gcloud storage cat')
+    );
     const removal = calls.findIndex((call) =>
       call.startsWith('gcloud storage rm')
     );
     const acquisition = calls.indexOf('ACQUIRED');
     expect(workingStatus).toBeGreaterThan(-1);
     expect(terminalStatus).toBeGreaterThan(workingStatus);
-    expect(generationRead).toBeGreaterThan(terminalStatus);
-    expect(removal).toBeGreaterThan(generationRead);
+    expect(generationRead).toBeGreaterThan(-1);
+    expect(workingStatus).toBeGreaterThan(generationRead);
+    expect(versionedPayloadReads).toHaveLength(2);
+    expect(versionedPayloadReads.every((call) =>
+      call.includes('production.lock#7')
+    )).toBe(true);
+    expect(removal).toBeGreaterThan(terminalStatus);
     expect(calls[removal]).toContain('--if-generation-match=7');
     expect(acquisition).toBeGreaterThan(removal);
     expect(calls.filter((call) =>

--- a/backend/src/services/__tests__/deployment-release-orchestration.test.ts
+++ b/backend/src/services/__tests__/deployment-release-orchestration.test.ts
@@ -1,0 +1,570 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repositoryRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+const promoteServiceScript = path.join(
+  repositoryRoot,
+  'deploy/cloudrun/promote-service.sh',
+);
+const releaseFullScript = path.join(
+  repositoryRoot,
+  'deploy/cloudrun/release-full.sh',
+);
+const acquireReleaseLockScript = path.join(
+  repositoryRoot,
+  'deploy/cloudrun/acquire-release-lock.sh',
+);
+const temporaryDirectories: string[] = [];
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function writeExecutable(
+  directory: string,
+  name: string,
+  source: string,
+): void {
+  const executablePath = path.join(directory, name);
+  writeFileSync(executablePath, source);
+  chmodSync(executablePath, 0o755);
+}
+
+function readLog(logPath: string): string[] {
+  return readFileSync(logPath, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('production release shell orchestration', () => {
+  it('rolls back and probes the previous revision after an ambiguous promotion failure', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-promotion-rollback-',
+    );
+    const fakeBin = path.join(temporaryRoot, 'bin');
+    const renderedDirectory = path.join(temporaryRoot, 'rendered');
+    mkdirSync(fakeBin);
+    mkdirSync(renderedDirectory);
+
+    const statePath = path.join(temporaryRoot, 'gcloud-state.json');
+    const logPath = path.join(temporaryRoot, 'calls.log');
+    writeFileSync(statePath, JSON.stringify({ phase: 'initial' }));
+
+    writeExecutable(fakeBin, 'gcloud', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GCLOUD_STATE;
+const logPath = process.env.FAKE_CALL_LOG;
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+const log = (message) => fs.appendFileSync(logPath, message + '\\n');
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const has = (prefix) => args.some((argument) => argument.startsWith(prefix));
+log('gcloud ' + args.join(' '));
+
+if (args.slice(0, 4).join(' ') === 'artifacts docker images describe') {
+  process.stdout.write('sha256:' + 'd'.repeat(64) + '\\n');
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'run services describe') {
+  const previous = {
+    revisionName: 'letter-archive-frontend-r-prev',
+    percent: 100,
+  };
+  if (state.phase === 'candidate') {
+    process.stdout.write(JSON.stringify({
+      status: {
+        traffic: [
+          previous,
+          {
+            revisionName:
+              'letter-archive-frontend-r-aaaaaaaaaa-bbbbbbbb',
+            percent: 0,
+            tag: 'c-aaaaaaaa-bbbbbbbb',
+            url: 'https://candidate.test',
+          },
+        ],
+      },
+    }));
+  } else {
+    process.stdout.write(JSON.stringify({
+      status: { traffic: [previous] },
+    }));
+  }
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'run services replace') {
+  state.phase = 'candidate';
+  save();
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'run services update-traffic') {
+  if (has('--to-tags=')) {
+    // Model the important ambiguous boundary: production accepted the traffic
+    // mutation, but the CLI lost the success response and exits nonzero.
+    state.phase = 'promoted';
+    save();
+    process.exit(9);
+  }
+  if (has('--to-revisions=letter-archive-frontend-r-prev=100')) {
+    state.phase = 'restored';
+    save();
+    process.exit(0);
+  }
+}
+
+process.stderr.write('Unexpected fake gcloud call: ' + args.join(' ') + '\\n');
+process.exit(98);
+`);
+
+    writeExecutable(fakeBin, 'curl', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const url = args[args.length - 1];
+fs.appendFileSync(process.env.FAKE_CALL_LOG, 'curl ' + url + '\\n');
+if (url === 'https://candidate.test/version.json') {
+  process.stdout.write(
+    '{"releaseSha":"' + process.env.FAKE_RELEASE_SHA + '"}',
+  );
+}
+`);
+
+    const imageRepository =
+      'us-east1-docker.pkg.dev/test-project/repo/frontend';
+    const releaseSha = 'a'.repeat(40);
+    const serviceAccount =
+      'frontend@test-project.iam.gserviceaccount.com';
+    const manifestPath = path.join(
+      renderedDirectory,
+      'frontend-service.yaml',
+    );
+    writeFileSync(manifestPath, `apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: letter-archive-frontend
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+    spec:
+      serviceAccountName: ${serviceAccount}
+      containers:
+        - image: ${imageRepository}@sha256:${'d'.repeat(64)}
+          resources:
+            limits:
+              memory: 256Mi
+  traffic:
+    - percent: 100
+      latestRevision: true
+`);
+
+    const result = spawnSync('/bin/bash', [promoteServiceScript], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: {
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_CALL_LOG: logPath,
+        FAKE_GCLOUD_STATE: statePath,
+        FAKE_RELEASE_SHA: releaseSha,
+        LETTER_ARCHIVE_PROJECT_ID: 'test-project',
+        LETTER_ARCHIVE_REGION: 'us-east1',
+        LETTER_ARCHIVE_SERVICE: 'letter-archive-frontend',
+        LETTER_ARCHIVE_SERVICE_ACCOUNT: serviceAccount,
+        LETTER_ARCHIVE_IMAGE_REPOSITORY: imageRepository,
+        LETTER_ARCHIVE_RELEASE_SHA: releaseSha,
+        LETTER_ARCHIVE_BUILD_ID: 'bbbbbbbb-bbbb-bbbb',
+        LETTER_ARCHIVE_PRODUCTION_URL: 'https://prod.test',
+        LETTER_ARCHIVE_SERVICE_MANIFEST: manifestPath,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(9);
+    expect(result.stderr).toContain(
+      'Release failed after promotion; restoring '
+      + 'letter-archive-frontend-r-prev',
+    );
+    expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual({
+      phase: 'restored',
+    });
+
+    const calls = readLog(logPath);
+    const ambiguousPromotion = calls.findIndex((call) =>
+      call.includes(
+        'run services update-traffic letter-archive-frontend',
+      )
+      && call.includes('--to-tags=c-aaaaaaaa-bbbbbbbb=100')
+    );
+    const rollback = calls.findIndex((call) =>
+      call.includes(
+        '--to-revisions=letter-archive-frontend-r-prev=100',
+      )
+    );
+    const restoredProbe = calls.findIndex(
+      (call) => call === 'curl https://prod.test/admin-login',
+    );
+    expect(ambiguousPromotion).toBeGreaterThan(-1);
+    expect(rollback).toBeGreaterThan(ambiguousPromotion);
+    expect(restoredProbe).toBeGreaterThan(rollback);
+  }, 30_000);
+
+  it.each([
+    {
+      failureStage: 'backend',
+      expectedStatus: 41,
+      shouldRestoreJobs: true,
+    },
+    {
+      failureStage: 'frontend',
+      expectedStatus: 42,
+      shouldRestoreJobs: false,
+    },
+  ])(
+    'restores release jobs only before the backend commit ($failureStage failure)',
+    ({ failureStage, expectedStatus, shouldRestoreJobs }) => {
+      const temporaryRoot = createTemporaryDirectory(
+        `letter-archive-full-release-${failureStage}-`,
+      );
+      const fakeBin = path.join(temporaryRoot, 'bin');
+      const renderedDirectory = path.join(
+        temporaryRoot,
+        'rendered/cloudrun',
+      );
+      mkdirSync(fakeBin);
+      mkdirSync(renderedDirectory, { recursive: true });
+
+      const statePath = path.join(temporaryRoot, 'gcloud-state.json');
+      const logPath = path.join(temporaryRoot, 'calls.log');
+      writeFileSync(statePath, JSON.stringify({
+        workerImage: 'registry.test/backend@sha256:oldworker',
+        backfillImage: 'registry.test/backend@sha256:oldbackfill',
+        scheduler: 'ENABLED',
+        iamRemoved: false,
+      }));
+
+      writeExecutable(fakeBin, 'bash', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(
+  process.env.FAKE_CALL_LOG,
+  'bash ' + process.env.LETTER_ARCHIVE_SERVICE + ' ' + args.join(' ') + '\\n',
+);
+if (args[0] === 'deploy/cloudrun/promote-service.sh') {
+  if (
+    process.env.FAKE_FAILURE_STAGE === 'backend'
+    && process.env.LETTER_ARCHIVE_SERVICE === 'letter-archive-backend'
+  ) process.exit(41);
+  if (
+    process.env.FAKE_FAILURE_STAGE === 'frontend'
+    && process.env.LETTER_ARCHIVE_SERVICE === 'letter-archive-frontend'
+  ) process.exit(42);
+  process.exit(0);
+}
+process.stderr.write('Unexpected fake bash call: ' + args.join(' ') + '\\n');
+process.exit(97);
+`);
+
+      writeExecutable(fakeBin, 'gcloud', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GCLOUD_STATE;
+const logPath = process.env.FAKE_CALL_LOG;
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+const log = (message) => fs.appendFileSync(logPath, message + '\\n');
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const command = args.slice(0, 3).join(' ');
+log('gcloud ' + args.join(' '));
+
+if (command === 'run jobs describe') {
+  const job = args[3];
+  if (args.includes('--format=export')) {
+    process.stdout.write(
+      'apiVersion: run.googleapis.com/v1\\n'
+      + 'kind: Job\\nmetadata:\\n  name: ' + job + '\\n',
+    );
+  } else if (job === 'letter-archive-worker') {
+    process.stdout.write(state.workerImage + '\\n');
+  } else if (job === 'letter-archive-backfill-dimensions') {
+    process.stdout.write(state.backfillImage + '\\n');
+  }
+  process.exit(0);
+}
+
+if (command === 'run jobs get-iam-policy') {
+  if (state.iamRemoved) {
+    process.stdout.write('{"bindings":[]}');
+  } else {
+    process.stdout.write(JSON.stringify({
+      bindings: [{
+        role: 'roles/run.invoker',
+        members: [
+          'serviceAccount:backend@test-project.iam.gserviceaccount.com',
+          'serviceAccount:worker@test-project.iam.gserviceaccount.com',
+        ],
+      }],
+    }));
+  }
+  process.exit(0);
+}
+
+if (command === 'run jobs remove-iam-policy-binding') {
+  state.iamRemoved = true;
+  save();
+  process.exit(0);
+}
+
+if (command === 'run jobs set-iam-policy') {
+  state.iamRemoved = false;
+  save();
+  process.exit(0);
+}
+
+if (command === 'run jobs replace') {
+  const manifest = args[3];
+  if (manifest === 'rendered/cloudrun/backend-worker-job.yaml') {
+    state.workerImage = 'registry.test/backend@sha256:newworker';
+  } else if (
+    manifest === 'rendered/cloudrun/backend-backfill-dimensions-job.yaml'
+  ) {
+    state.backfillImage = 'registry.test/backend@sha256:newbackfill';
+  } else if (manifest === 'rendered/release-state/worker.yaml') {
+    state.workerImage = 'registry.test/backend@sha256:oldworker';
+  } else if (manifest === 'rendered/release-state/backfill.yaml') {
+    state.backfillImage = 'registry.test/backend@sha256:oldbackfill';
+  }
+  save();
+  process.exit(0);
+}
+
+if (command === 'run jobs execute') process.exit(0);
+
+if (args.slice(0, 3).join(' ') === 'services list --project=test-project') {
+  process.stdout.write('cloudscheduler.googleapis.com\\n');
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'scheduler jobs describe') {
+  process.stdout.write(state.scheduler + '\\n');
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'scheduler jobs pause') {
+  state.scheduler = 'PAUSED';
+  save();
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'scheduler jobs resume') {
+  state.scheduler = 'ENABLED';
+  save();
+  process.exit(0);
+}
+
+process.stderr.write('Unexpected fake gcloud call: ' + args.join(' ') + '\\n');
+process.exit(98);
+`);
+
+      const result = spawnSync('/bin/bash', [releaseFullScript], {
+        cwd: temporaryRoot,
+        encoding: 'utf8',
+        env: {
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          FAKE_CALL_LOG: logPath,
+          FAKE_FAILURE_STAGE: failureStage,
+          FAKE_GCLOUD_STATE: statePath,
+          LETTER_ARCHIVE_PROJECT_ID: 'test-project',
+          LETTER_ARCHIVE_REGION: 'us-east1',
+          LETTER_ARCHIVE_RELEASE_SHA: 'a'.repeat(40),
+          LETTER_ARCHIVE_BUILD_ID: 'bbbbbbbb-bbbb-bbbb',
+          LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT:
+            'backend@test-project.iam.gserviceaccount.com',
+          LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT:
+            'frontend@test-project.iam.gserviceaccount.com',
+          LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT:
+            'worker@test-project.iam.gserviceaccount.com',
+          LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY:
+            'us-east1-docker.pkg.dev/test-project/repo/backend',
+          LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY:
+            'us-east1-docker.pkg.dev/test-project/repo/frontend',
+          LETTER_ARCHIVE_BACKEND_PRODUCTION_URL:
+            'https://api.prod.test',
+          LETTER_ARCHIVE_FRONTEND_PRODUCTION_URL:
+            'https://prod.test',
+        },
+      });
+
+      expect(result.status).toBe(expectedStatus);
+      const state = JSON.parse(readFileSync(statePath, 'utf8')) as {
+        workerImage: string;
+        backfillImage: string;
+        scheduler: string;
+        iamRemoved: boolean;
+      };
+      expect(state.scheduler).toBe('ENABLED');
+
+      const calls = readLog(logPath);
+      const restoredWorker = calls.some((call) =>
+        call.includes(
+          'run jobs replace rendered/release-state/worker.yaml',
+        )
+      );
+      const restoredBackfill = calls.some((call) =>
+        call.includes(
+          'run jobs replace rendered/release-state/backfill.yaml',
+        )
+      );
+      const restoredPolicy = calls.some((call) =>
+        call.includes('run jobs set-iam-policy letter-archive-worker')
+      );
+      expect(restoredWorker).toBe(shouldRestoreJobs);
+      expect(restoredBackfill).toBe(shouldRestoreJobs);
+      expect(restoredPolicy).toBe(shouldRestoreJobs);
+
+      if (shouldRestoreJobs) {
+        expect(state.workerImage).toContain('oldworker');
+        expect(state.backfillImage).toContain('oldbackfill');
+        expect(state.iamRemoved).toBe(false);
+      } else {
+        expect(state.workerImage).toContain('newworker');
+        expect(state.backfillImage).toContain('newbackfill');
+      }
+    },
+    30_000,
+  );
+
+  it('reaps only a terminal lock owner using generation preconditions', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-release-lock-',
+    );
+    const fakeBin = path.join(temporaryRoot, 'bin');
+    mkdirSync(fakeBin);
+
+    const statePath = path.join(temporaryRoot, 'gcloud-state.json');
+    const logPath = path.join(temporaryRoot, 'calls.log');
+    writeFileSync(statePath, JSON.stringify({
+      locked: true,
+      statusCalls: 0,
+    }));
+
+    writeExecutable(fakeBin, 'sleep', `#!/usr/bin/env node
+require('node:fs').appendFileSync(
+  process.env.FAKE_CALL_LOG,
+  'sleep ' + process.argv.slice(2).join(' ') + '\\n',
+);
+`);
+
+    writeExecutable(fakeBin, 'gcloud', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GCLOUD_STATE;
+const logPath = process.env.FAKE_CALL_LOG;
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+const log = (message) => fs.appendFileSync(logPath, message + '\\n');
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+log('gcloud ' + args.join(' '));
+
+if (args.slice(0, 2).join(' ') === 'storage cp') {
+  fs.readFileSync(0, 'utf8');
+  if (state.locked) process.exit(1);
+  log('ACQUIRED');
+  process.exit(0);
+}
+
+if (args.slice(0, 2).join(' ') === 'storage cat') {
+  process.stdout.write(
+    '11111111-1111-1111-1111-111111111111 ' + 'c'.repeat(40),
+  );
+  process.exit(0);
+}
+
+if (args.slice(0, 2).join(' ') === 'builds describe') {
+  state.statusCalls += 1;
+  const status = state.statusCalls === 1 ? 'WORKING' : 'FAILURE';
+  save();
+  log('STATUS ' + status);
+  process.stdout.write(status + '\\n');
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'storage objects describe') {
+  process.stdout.write('7\\n');
+  process.exit(0);
+}
+
+if (args.slice(0, 2).join(' ') === 'storage rm') {
+  if (!args.includes('--if-generation-match=7')) process.exit(96);
+  state.locked = false;
+  save();
+  process.exit(0);
+}
+
+process.stderr.write('Unexpected fake gcloud call: ' + args.join(' ') + '\\n');
+process.exit(98);
+`);
+
+    const result = spawnSync('/bin/bash', [acquireReleaseLockScript], {
+      cwd: temporaryRoot,
+      encoding: 'utf8',
+      env: {
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_CALL_LOG: logPath,
+        FAKE_GCLOUD_STATE: statePath,
+        LETTER_ARCHIVE_PROJECT_ID: 'test-project',
+        LETTER_ARCHIVE_REGION: 'us-east1',
+        LETTER_ARCHIVE_RELEASE_SHA: 'a'.repeat(40),
+        LETTER_ARCHIVE_BUILD_ID:
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        LETTER_ARCHIVE_RELEASE_LOCK_BUCKET:
+          'test-project-release-lock',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Acquired production release lock');
+
+    const calls = readLog(logPath);
+    const workingStatus = calls.indexOf('STATUS WORKING');
+    const terminalStatus = calls.indexOf('STATUS FAILURE');
+    const generationRead = calls.findIndex((call) =>
+      call.startsWith('gcloud storage objects describe')
+    );
+    const removal = calls.findIndex((call) =>
+      call.startsWith('gcloud storage rm')
+    );
+    const acquisition = calls.indexOf('ACQUIRED');
+    expect(workingStatus).toBeGreaterThan(-1);
+    expect(terminalStatus).toBeGreaterThan(workingStatus);
+    expect(generationRead).toBeGreaterThan(terminalStatus);
+    expect(removal).toBeGreaterThan(generationRead);
+    expect(calls[removal]).toContain('--if-generation-match=7');
+    expect(acquisition).toBeGreaterThan(removal);
+    expect(calls.filter((call) =>
+      call.startsWith('gcloud storage rm')
+    )).toHaveLength(1);
+    expect(calls.filter((call) =>
+      call.startsWith('gcloud storage cp')
+    ).every((call) => call.includes('--if-generation-match=0'))).toBe(true);
+  }, 30_000);
+});

--- a/backend/src/services/__tests__/deployment-release-scope.test.ts
+++ b/backend/src/services/__tests__/deployment-release-scope.test.ts
@@ -1,0 +1,126 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repositoryRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+const scopeScript = path.join(
+  repositoryRoot,
+  'deploy/cloudrun/select-release-scope.sh',
+);
+const temporaryDirectories: string[] = [];
+
+function createRepository(): {
+  directory: string;
+  commits: string[];
+} {
+  const directory = mkdtempSync(
+    path.join(os.tmpdir(), 'letter-archive-release-scope-'),
+  );
+  temporaryDirectories.push(directory);
+  execFileSync('git', ['init', '--quiet'], { cwd: directory });
+  execFileSync('git', ['config', 'user.email', 'test@example.test'], {
+    cwd: directory,
+  });
+  execFileSync('git', ['config', 'user.name', 'Release Scope Test'], {
+    cwd: directory,
+  });
+
+  const commits: string[] = [];
+  const commit = (file: string, contents: string): void => {
+    const absolutePath = path.join(directory, file);
+    writeFileSync(absolutePath, contents);
+    execFileSync('git', ['add', file], { cwd: directory });
+    execFileSync('git', ['commit', '--quiet', '-m', file], { cwd: directory });
+    commits.push(
+      execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: directory,
+        encoding: 'utf8',
+      }).trim(),
+    );
+  };
+
+  commit('README.md', 'initial\n');
+  execFileSync('mkdir', ['-p', 'frontend'], { cwd: directory });
+  commit('frontend/app.ts', 'frontend one\n');
+  execFileSync('mkdir', ['-p', 'backend'], { cwd: directory });
+  commit('backend/app.ts', 'backend one\n');
+  return { directory, commits };
+}
+
+function selectScope(
+  directory: string,
+  backendRevision: string,
+  frontendRevision: string,
+  headRevision: string,
+): string {
+  return execFileSync(
+    'bash',
+    [scopeScript, backendRevision, frontendRevision, headRevision],
+    { cwd: directory, encoding: 'utf8' },
+  ).trim();
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('production release scope selection', () => {
+  it('skips an older workflow after a newer full release', () => {
+    const { directory, commits } = createRepository();
+    expect(selectScope(
+      directory,
+      commits[2],
+      commits[2],
+      commits[1],
+    )).toBe('stale');
+  });
+
+  it('skips an older workflow when only one live marker is newer', () => {
+    const { directory, commits } = createRepository();
+    expect(selectScope(
+      directory,
+      commits[0],
+      commits[2],
+      commits[1],
+    )).toBe('stale');
+  });
+
+  it('carries a missed backend release into a later full release', () => {
+    const { directory, commits } = createRepository();
+    expect(selectScope(
+      directory,
+      commits[0],
+      commits[1],
+      commits[2],
+    )).toBe('full');
+  });
+
+  it('converges the frontend after a partial full release', () => {
+    const { directory, commits } = createRepository();
+    expect(selectScope(
+      directory,
+      commits[2],
+      commits[1],
+      commits[2],
+    )).toBe('frontend');
+  });
+
+  it('selects a frontend-only release from matching backend state', () => {
+    const { directory, commits } = createRepository();
+    expect(selectScope(
+      directory,
+      commits[0],
+      commits[0],
+      commits[1],
+    )).toBe('frontend');
+  });
+});

--- a/backend/src/services/__tests__/processing-ownership.architecture.test.ts
+++ b/backend/src/services/__tests__/processing-ownership.architecture.test.ts
@@ -153,9 +153,17 @@ describe('processing execution ownership', () => {
         file.startsWith('cloudbuild')
         && file.endsWith('.yaml')
       ));
-    const pushValidationFiles = cloudBuildFiles.filter(
-      (file) => file !== 'cloudbuild.deploy.yaml',
-    );
+    expect(cloudBuildFiles.sort()).toEqual([
+      'cloudbuild-frontend.yaml',
+      'cloudbuild.deploy.yaml',
+      'cloudbuild.frontend-release.yaml',
+      'cloudbuild.release.yaml',
+      'cloudbuild.yaml',
+    ]);
+    const pushValidationFiles = [
+      'cloudbuild-frontend.yaml',
+      'cloudbuild.yaml',
+    ];
     const [pushValidations, controlledDeploy] = await Promise.all([
       Promise.all(pushValidationFiles.map(async (file) => ({
         file,
@@ -167,10 +175,6 @@ describe('processing execution ownership', () => {
       ),
     ]);
 
-    expect(pushValidationFiles.sort()).toEqual([
-      'cloudbuild-frontend.yaml',
-      'cloudbuild.yaml',
-    ]);
     for (const { file, source } of pushValidations) {
       expect(source, file).toContain('-validation:${BUILD_ID}');
       expect(source, file).not.toMatch(
@@ -188,17 +192,33 @@ describe('processing execution ownership', () => {
       "_CONFIRM_WRITE_QUIESCENCE: 'false'",
     );
     expect(controlledDeploy).toContain(
-      'if [[ "${_CONFIRM_WRITE_QUIESCENCE}" != "true" ]]',
+      'if [[ "$${LETTER_ARCHIVE_CONFIRM_MAINTENANCE}" != "true" ]]',
     );
     expect(controlledDeploy).toContain(
-      'if [[ ! "${_TAG}" =~ ^[0-9a-f]{40}$ ]]',
+      'if [[ ! "$${LETTER_ARCHIVE_RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]',
+    );
+    expect(controlledDeploy).toContain(
+      'deploy/cloudrun/prepare-release-manifests.sh',
+    );
+    expect(controlledDeploy).not.toContain('-e "s|REGION|');
+    expect(controlledDeploy).not.toContain(
+      'export LETTER_ARCHIVE_REGION="${_REGION}"',
     );
     expect(controlledDeploy.match(/waitFor: \['-'\]/g)).toHaveLength(1);
     expect(controlledDeploy).toMatch(
-      /id: confirm-write-quiescence[\s\S]*?waitFor: \['-'\]/,
+      /id: verify-source[\s\S]*?waitFor: \['-'\]/,
+    );
+    expect(controlledDeploy).toMatch(
+      /id: confirm-write-quiescence[\s\S]*?waitFor: \['verify-current-main'\]/,
     );
     expect(controlledDeploy).toMatch(
       /id: deploy-frontend[\s\S]*?waitFor: \[[^\]]*'deploy-backend'[^\]]*\]/,
+    );
+    expect(controlledDeploy).toMatch(
+      /id: establish-write-quiescence[\s\S]*?deploy\/cloudrun\/quiesce-production\.sh/,
+    );
+    expect(controlledDeploy).not.toContain(
+      'worker-pools delete letter-archive-worker \\\n          --region=${_REGION} --quiet || true',
     );
     expect(controlledDeploy).toMatch(
       /id: deploy-backend[\s\S]*?waitFor:[\s\S]*?- grant-backend-worker-job-invoke/,
@@ -208,11 +228,104 @@ describe('processing execution ownership', () => {
     const backendWorkerGrant = controlledDeploy.indexOf(
       'id: grant-backend-worker-job-invoke',
     );
+    const workerHandoffGrant = controlledDeploy.indexOf(
+      'id: grant-worker-handoff-job-invoke',
+    );
     const backendDeploy = controlledDeploy.indexOf('id: deploy-backend');
 
     expect(workerDeploy).toBeGreaterThan(-1);
     expect(backendWorkerGrant).toBeGreaterThan(workerDeploy);
+    expect(workerHandoffGrant).toBeGreaterThan(workerDeploy);
     expect(backendDeploy).toBeGreaterThan(backendWorkerGrant);
+    expect(backendDeploy).toBeGreaterThan(workerHandoffGrant);
+  });
+
+  it('keeps automatic releases exact-SHA, serialized, and migration-gated', async () => {
+    const [
+      workflow,
+      fullRelease,
+      frontendRelease,
+      fullReleaseScript,
+      migrationPolicy,
+    ] = await Promise.all([
+      readFile(
+        path.join(repositoryRoot, '.github/workflows/ci.yml'),
+        'utf8',
+      ),
+      readFile(
+        path.join(repositoryRoot, 'cloudbuild.release.yaml'),
+        'utf8',
+      ),
+      readFile(
+        path.join(repositoryRoot, 'cloudbuild.frontend-release.yaml'),
+        'utf8',
+      ),
+      readFile(
+        path.join(repositoryRoot, 'deploy/cloudrun/release-full.sh'),
+        'utf8',
+      ),
+      readFile(
+        path.join(sourceRoot, 'db/migration-release-policy.ts'),
+        'utf8',
+      ),
+    ]);
+
+    expect(workflow).toContain('group: letter-archive-production');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).toContain(
+      "vars.AUTOMATIC_RELEASES_ENABLED == 'true'",
+    );
+    expect(workflow).toContain(
+      'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3',
+    );
+    expect(workflow).toContain(
+      'https://api.voicesthatremain.com/health',
+    );
+    expect(workflow).toContain(
+      'https://voicesthatremain.com/version.json',
+    );
+    expect(workflow).not.toContain('github.event.before');
+    expect(workflow).toContain('--git-source-revision="$RELEASE_SHA"');
+    expect(workflow).toContain('--substitutions="_TAG=$RELEASE_SHA"');
+
+    for (const [file, source] of [
+      ['cloudbuild.release.yaml', fullRelease],
+      ['cloudbuild.frontend-release.yaml', frontendRelease],
+    ]) {
+      expect(source, file).toContain('id: verify-source');
+      expect(source, file).toContain(
+        'deploy/cloudrun/verify-build-source.sh',
+      );
+      expect(source, file).toContain('LETTER_ARCHIVE_RELEASE_SHA=${_TAG}');
+      expect(source, file).not.toContain('latestRevision: true');
+    }
+    expect(fullRelease).toContain('deploy/cloudrun/release-full.sh');
+    expect(fullReleaseScript).toContain(
+      'bash deploy/cloudrun/promote-service.sh',
+    );
+    expect(frontendRelease).toContain(
+      'deploy/cloudrun/promote-service.sh',
+    );
+
+    expect(fullRelease).toContain(
+      'LETTER_ARCHIVE_MIGRATION_RELEASE_MODE=automatic',
+    );
+    expect(fullReleaseScript).toContain(
+      'gcloud run jobs execute letter-archive-migrate',
+    );
+    expect(fullReleaseScript.indexOf(
+      'gcloud run jobs execute letter-archive-migrate',
+    )).toBeLessThan(
+      fullReleaseScript.indexOf(
+        'export LETTER_ARCHIVE_SERVICE=letter-archive-backend',
+      ),
+    );
+    expect(frontendRelease).not.toMatch(
+      /\b(?:run-migrations|backend-migrate-job|promote-backend)\b/,
+    );
+    expect(migrationPolicy).toContain(
+      "automaticMigrationBaselineTag =\n  '0056_repair_extra_content_job_ownership'",
+    );
   });
 
   it('keeps scheduled worker reconciliation authenticated and ordered after invoker grants', async () => {
@@ -244,19 +357,19 @@ describe('processing execution ownership', () => {
     expect(scheduleStep).toBeGreaterThan(schedulerGrant);
 
     expect(controlledDeploy.slice(backendGrant, schedulerGrant)).toContain(
-      '--member=serviceAccount:${_SERVICE_ACCOUNT}',
+      '--member=serviceAccount:${_BACKEND_SERVICE_ACCOUNT}',
     );
     expect(controlledDeploy.slice(backendGrant, schedulerGrant)).toContain(
       '--role=roles/run.invoker',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
-      '--member="serviceAccount:${_SCHEDULER_SERVICE_ACCOUNT}"',
+      '--member="serviceAccount:$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}"',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
       '--role=roles/run.invoker',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
-      'if [[ "${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}" != "true" ]]',
+      'if [[ "$${LETTER_ARCHIVE_ENABLE_SCHEDULER}" != "true" ]]',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
       "waitFor: ['grant-backend-worker-job-invoke']",
@@ -267,7 +380,7 @@ describe('processing execution ownership', () => {
       "waitFor: ['grant-scheduler-worker-job-invoke']",
     );
     expect(scheduleContract).toContain(
-      'if [[ "${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}" != "true" ]]',
+      'if [[ "$${LETTER_ARCHIVE_ENABLE_SCHEDULER}" != "true" ]]',
     );
     expect(scheduleContract).toContain(
       'gcloud scheduler jobs "$${scheduler_action}" http',
@@ -276,14 +389,14 @@ describe('processing execution ownership', () => {
       'gcloud scheduler jobs describe letter-archive-worker-reconcile',
     );
     expect(scheduleContract).toContain(
-      '--schedule="${_WORKER_RECONCILIATION_SCHEDULE}"',
+      '--schedule="$${LETTER_ARCHIVE_WORKER_SCHEDULE}"',
     );
     expect(scheduleContract).toContain('--time-zone=Etc/UTC');
     expect(scheduleContract).toContain(
-      '--uri="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${_REGION}/jobs/letter-archive-worker:run"',
+      '--uri="https://run.googleapis.com/v2/projects/$${LETTER_ARCHIVE_PROJECT_ID}/locations/$${LETTER_ARCHIVE_REGION}/jobs/letter-archive-worker:run"',
     );
     expect(scheduleContract).toContain(
-      '--oauth-service-account-email="${_SCHEDULER_SERVICE_ACCOUNT}"',
+      '--oauth-service-account-email="$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}"',
     );
     expect(scheduleContract).toContain(
       '--oauth-token-scope=https://www.googleapis.com/auth/cloud-platform',

--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -15,8 +15,13 @@ substitutions:
   _REGION: us-east1
   _CLOUD_SQL_INSTANCE: letter-archive-db
   _ARCHIVE_BUCKET: letter-archive-485110-archive
+  _RELEASE_LOCK_BUCKET: letter-archive-485110-release-lock
   _DOMAIN: voicesthatremain.com
-  _SERVICE_ACCOUNT: 'letter-archive-runner@${PROJECT_ID}.iam.gserviceaccount.com'
+  _BACKEND_SERVICE_ACCOUNT: 'letter-archive-backend@${PROJECT_ID}.iam.gserviceaccount.com'
+  _FRONTEND_SERVICE_ACCOUNT: 'letter-archive-frontend@${PROJECT_ID}.iam.gserviceaccount.com'
+  _WORKER_SERVICE_ACCOUNT: 'letter-archive-worker@${PROJECT_ID}.iam.gserviceaccount.com'
+  _MIGRATE_SERVICE_ACCOUNT: 'letter-archive-migrate@${PROJECT_ID}.iam.gserviceaccount.com'
+  _BACKFILL_SERVICE_ACCOUNT: 'letter-archive-backfill@${PROJECT_ID}.iam.gserviceaccount.com'
   _SCHEDULER_SERVICE_ACCOUNT: 'letter-archive-scheduler@${PROJECT_ID}.iam.gserviceaccount.com'
   _WORKER_RECONCILIATION_SCHEDULE: '*/5 * * * *'
   # Initial lease rollout must drain pre-lease executions before this is enabled.
@@ -30,34 +35,79 @@ options:
 
 steps:
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-source
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_BUILD_LOCATION=${_REGION}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+    args:
+      - deploy/cloudrun/verify-build-source.sh
+    waitFor: ['-']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: acquire-release-lock
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_LOCK_BUCKET=${_RELEASE_LOCK_BUCKET}'
+    args:
+      - deploy/cloudrun/acquire-release-lock.sh
+    waitFor: ['verify-source']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-current-main
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+    args:
+      - deploy/cloudrun/verify-current-main.sh
+    waitFor: ['acquire-release-lock']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: confirm-write-quiescence
     entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_CONFIRM_MAINTENANCE=${_CONFIRM_WRITE_QUIESCENCE}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
     args:
       - -c
       - |
         set -euo pipefail
-        if [[ "${_CONFIRM_WRITE_QUIESCENCE}" != "true" ]]; then
-          echo "Refusing deployment: pause workers, Scheduler, and administrative writes; drain all old API/worker processes; then pass _CONFIRM_WRITE_QUIESCENCE=true."
+        if [[ "$${LETTER_ARCHIVE_CONFIRM_MAINTENANCE}" != "true" ]]; then
+          echo "Refusing deployment: pass _CONFIRM_WRITE_QUIESCENCE=true to authorize the enforced maintenance window."
           exit 1
         fi
-        if [[ ! "${_TAG}" =~ ^[0-9a-f]{40}$ ]]; then
+        if [[ ! "$${LETTER_ARCHIVE_RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
           echo "Refusing deployment: _TAG must be the full lowercase Git commit SHA selected as the build source."
           exit 1
         fi
-        echo "Write quiescence acknowledged for source commit ${_TAG}."
-    waitFor: ['-']
+        echo "Maintenance release authorized for source commit $${LETTER_ARCHIVE_RELEASE_SHA}."
+    waitFor: ['verify-current-main']
 
   # ── Pull cached images for layer reuse ───────────────────────
   - name: gcr.io/cloud-builders/docker
     id: pull-backend-cache
     entrypoint: bash
-    args: ['-c', 'docker pull ${_BACKEND_IMAGE}:latest || true']
+    env:
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_BACKEND_IMAGE}'
+    args:
+      - -c
+      - docker pull "$$LETTER_ARCHIVE_IMAGE_REPOSITORY:latest" || true
     waitFor: ['confirm-write-quiescence']
 
   - name: gcr.io/cloud-builders/docker
     id: pull-frontend-cache
     entrypoint: bash
-    args: ['-c', 'docker pull ${_FRONTEND_IMAGE}:latest || true']
+    env:
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+    args:
+      - -c
+      - docker pull "$$LETTER_ARCHIVE_IMAGE_REPOSITORY:latest" || true
     waitFor: ['confirm-write-quiescence']
 
   # ── Build images (parallel) ────────────────────────────────
@@ -90,6 +140,8 @@ steps:
       - 'VITE_API_URL=https://api.${_DOMAIN}'
       - --build-arg
       - 'VITE_SITE_URL=https://${_DOMAIN}'
+      - --build-arg
+      - 'RELEASE_SHA=${_TAG}'
       - -f
       - frontend/Dockerfile
       - frontend
@@ -110,23 +162,40 @@ steps:
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: prepare-manifests
     entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_CLOUD_SQL_INSTANCE=${_CLOUD_SQL_INSTANCE}'
+      - 'LETTER_ARCHIVE_ARCHIVE_BUCKET=${_ARCHIVE_BUCKET}'
+      - 'LETTER_ARCHIVE_DOMAIN=${_DOMAIN}'
+      - 'LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT=${_BACKEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT=${_WORKER_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT=${_MIGRATE_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT=${_BACKFILL_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_MIGRATION_RELEASE_MODE=maintenance'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY=${_BACKEND_IMAGE}'
+      - 'LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
     args:
-      - -c
-      - |
-        for f in deploy/cloudrun/*.yaml; do
-          sed -i \
-            -e "s|SERVICE_ACCOUNT_EMAIL|${_SERVICE_ACCOUNT}|g" \
-            -e "s|CLOUD_SQL_INSTANCE|${_CLOUD_SQL_INSTANCE}|g" \
-            -e "s|ARCHIVE_BUCKET|${_ARCHIVE_BUCKET}|g" \
-            -e "s|BACKEND_IMAGE|${_BACKEND_IMAGE}:${_TAG}|g" \
-            -e "s|FRONTEND_IMAGE|${_FRONTEND_IMAGE}:${_TAG}|g" \
-            -e "s|PROJECT_NUMBER|${PROJECT_ID}|g" \
-            -e "s|PROJECT_ID|${PROJECT_ID}|g" \
-            -e "s|YOUR_DOMAIN|${_DOMAIN}|g" \
-            -e "s|REGION|${_REGION}|g" \
-            "$$f"
-        done
-    waitFor: ['confirm-write-quiescence']
+      - deploy/cloudrun/prepare-release-manifests.sh
+    waitFor: ['push-backend', 'push-frontend']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: establish-write-quiescence
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+      - 'LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT=${_BACKEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT=${_WORKER_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+    args:
+      - deploy/cloudrun/quiesce-production.sh
+    waitFor: ['push-backend', 'push-frontend']
 
   # ── Deploy + run migrations ─────────────────────────────────
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -136,9 +205,12 @@ steps:
       - run
       - jobs
       - replace
-      - deploy/cloudrun/backend-migrate-job.yaml
+      - rendered/cloudrun/backend-migrate-job.yaml
       - --region=${_REGION}
-    waitFor: ['push-backend', 'prepare-manifests']
+    waitFor:
+      - push-backend
+      - prepare-manifests
+      - establish-write-quiescence
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: run-migrations
@@ -160,21 +232,11 @@ steps:
       - run
       - jobs
       - replace
-      - deploy/cloudrun/backend-backfill-dimensions-job.yaml
+      - rendered/cloudrun/backend-backfill-dimensions-job.yaml
       - --region=${_REGION}
     waitFor: ['push-backend', 'prepare-manifests']
 
   # ── Deploy worker job ───────────────────────────────────────
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    id: delete-legacy-worker-pool
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        gcloud beta run worker-pools delete letter-archive-worker \
-          --region=${_REGION} --quiet || true
-    waitFor: ['run-migrations']
-
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: deploy-worker
     entrypoint: gcloud
@@ -182,9 +244,9 @@ steps:
       - run
       - jobs
       - replace
-      - deploy/cloudrun/backend-worker-job.yaml
+      - rendered/cloudrun/backend-worker-job.yaml
       - --region=${_REGION}
-    waitFor: ['delete-legacy-worker-pool', 'prepare-manifests']
+    waitFor: ['run-migrations', 'prepare-manifests']
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: grant-backend-worker-job-invoke
@@ -195,7 +257,20 @@ steps:
       - add-iam-policy-binding
       - letter-archive-worker
       - --region=${_REGION}
-      - --member=serviceAccount:${_SERVICE_ACCOUNT}
+      - --member=serviceAccount:${_BACKEND_SERVICE_ACCOUNT}
+      - --role=roles/run.invoker
+    waitFor: ['deploy-worker']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: grant-worker-handoff-job-invoke
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - add-iam-policy-binding
+      - letter-archive-worker
+      - --region=${_REGION}
+      - --member=serviceAccount:${_WORKER_SERVICE_ACCOUNT}
       - --role=roles/run.invoker
     waitFor: ['deploy-worker']
 
@@ -204,16 +279,43 @@ steps:
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: deploy-backend
     entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
     args:
       - -c
       - |
-        set -e
-        gcloud run services replace deploy/cloudrun/backend-service.yaml \
-          --region=${_REGION}
+        set -euo pipefail
+        gcloud run services replace rendered/cloudrun/backend-service.yaml \
+          --project="$${LETTER_ARCHIVE_PROJECT_ID}" \
+          --region="$${LETTER_ARCHIVE_REGION}"
+        service_url="$$(gcloud run services describe letter-archive-backend \
+          --project="$${LETTER_ARCHIVE_PROJECT_ID}" \
+          --region="$${LETTER_ARCHIVE_REGION}" \
+          --format='value(status.url)')"
+        identity_token="$$(gcloud auth print-identity-token \
+          --audiences="$${service_url}")"
+        health="$$(curl --retry 10 --retry-all-errors --retry-delay 3 -fsS \
+          -H "Authorization: Bearer $${identity_token}" \
+          "$${service_url}/health")"
+        if [[ "$${health}" != \
+          "{\"ok\":true,\"releaseSha\":\"$${LETTER_ARCHIVE_RELEASE_SHA}\"}" ]]; then
+          echo "Private backend release identity probe failed."
+          exit 1
+        fi
+        curl --retry 10 --retry-all-errors --retry-delay 3 -fsS \
+          -H "Authorization: Bearer $${identity_token}" \
+          "$${service_url}/health/ready" >/dev/null
+        curl --retry 10 --retry-all-errors --retry-delay 3 -fsS \
+          -H "Authorization: Bearer $${identity_token}" \
+          "$${service_url}/auth/status" >/dev/null
         binding_applied=false
         for i in 1 2 3; do
           if gcloud run services add-iam-policy-binding letter-archive-backend \
-            --region=${_REGION} --member=allUsers --role=roles/run.invoker --quiet; then
+            --project="$${LETTER_ARCHIVE_PROJECT_ID}" \
+            --region="$${LETTER_ARCHIVE_REGION}" \
+            --member=allUsers --role=roles/run.invoker --quiet; then
             binding_applied=true
             break
           fi
@@ -228,47 +330,44 @@ steps:
       - run-migrations
       - prepare-manifests
       - grant-backend-worker-job-invoke
+      - grant-worker-handoff-job-invoke
 
   # ── Deploy frontend service ─────────────────────────────────
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: deploy-frontend
     entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_SERVICE=letter-archive-frontend'
+      - 'LETTER_ARCHIVE_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_PRODUCTION_URL=https://${_DOMAIN}'
+      - 'LETTER_ARCHIVE_SERVICE_MANIFEST=rendered/cloudrun/frontend-service.yaml'
     args:
-      - -c
-      - |
-        set -e
-        gcloud run services replace deploy/cloudrun/frontend-service.yaml \
-          --region=${_REGION}
-        binding_applied=false
-        for i in 1 2 3; do
-          if gcloud run services add-iam-policy-binding letter-archive-frontend \
-            --region=${_REGION} --member=allUsers --role=roles/run.invoker --quiet; then
-            binding_applied=true
-            break
-          fi
-          echo "IAM binding retry $$i/3 (frontend)..."
-          sleep $$((i * 2))
-        done
-        if [[ "$${binding_applied}" != "true" ]]; then
-          echo "Failed to apply the public frontend invoker binding."
-          exit 1
-        fi
+      - deploy/cloudrun/promote-service.sh
     waitFor: ['push-frontend', 'prepare-manifests', 'deploy-backend']
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: grant-scheduler-worker-job-invoke
     entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_ENABLE_SCHEDULER=${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT=${_SCHEDULER_SERVICE_ACCOUNT}'
     args:
       - -c
       - |
         set -euo pipefail
-        if [[ "${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}" != "true" ]]; then
+        if [[ "$${LETTER_ARCHIVE_ENABLE_SCHEDULER}" != "true" ]]; then
           echo "Scheduled worker reconciliation remains disabled for this deployment."
           exit 0
         fi
         gcloud run jobs add-iam-policy-binding letter-archive-worker \
-          --region="${_REGION}" \
-          --member="serviceAccount:${_SCHEDULER_SERVICE_ACCOUNT}" \
+          --region="$${LETTER_ARCHIVE_REGION}" \
+          --member="serviceAccount:$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}" \
           --role=roles/run.invoker
     waitFor: ['grant-backend-worker-job-invoke']
 
@@ -277,17 +376,23 @@ steps:
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: configure-worker-reconciliation-schedule
     entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_ENABLE_SCHEDULER=${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_WORKER_SCHEDULE=${_WORKER_RECONCILIATION_SCHEDULE}'
+      - 'LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT=${_SCHEDULER_SERVICE_ACCOUNT}'
     args:
       - -c
       - |
         set -euo pipefail
-        if [[ "${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}" != "true" ]]; then
+        if [[ "$${LETTER_ARCHIVE_ENABLE_SCHEDULER}" != "true" ]]; then
           echo "Skipping Scheduler configuration until the lease rollout is proven."
           exit 0
         fi
         if gcloud scheduler jobs describe letter-archive-worker-reconcile \
-          --project="${PROJECT_ID}" \
-          --location="${_REGION}" >/dev/null 2>&1; then
+          --project="$${LETTER_ARCHIVE_PROJECT_ID}" \
+          --location="$${LETTER_ARCHIVE_REGION}" >/dev/null 2>&1; then
           scheduler_action=update
         else
           scheduler_action=create
@@ -295,13 +400,13 @@ steps:
 
         gcloud scheduler jobs "$${scheduler_action}" http \
           letter-archive-worker-reconcile \
-          --project="${PROJECT_ID}" \
-          --location="${_REGION}" \
-          --schedule="${_WORKER_RECONCILIATION_SCHEDULE}" \
+          --project="$${LETTER_ARCHIVE_PROJECT_ID}" \
+          --location="$${LETTER_ARCHIVE_REGION}" \
+          --schedule="$${LETTER_ARCHIVE_WORKER_SCHEDULE}" \
           --time-zone=Etc/UTC \
-          --uri="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${_REGION}/jobs/letter-archive-worker:run" \
+          --uri="https://run.googleapis.com/v2/projects/$${LETTER_ARCHIVE_PROJECT_ID}/locations/$${LETTER_ARCHIVE_REGION}/jobs/letter-archive-worker:run" \
           --http-method=POST \
-          --oauth-service-account-email="${_SCHEDULER_SERVICE_ACCOUNT}" \
+          --oauth-service-account-email="$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}" \
           --oauth-token-scope=https://www.googleapis.com/auth/cloud-platform \
           --attempt-deadline=30s \
           --max-retry-attempts=0 \
@@ -310,4 +415,19 @@ steps:
           --quiet
     waitFor: ['grant-scheduler-worker-job-invoke']
 
-timeout: 2400s
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: release-production-lock
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_LOCK_BUCKET=${_RELEASE_LOCK_BUCKET}'
+    args:
+      - deploy/cloudrun/release-release-lock.sh
+    waitFor:
+      - configure-worker-reconciliation-schedule
+      - deploy-frontend
+      - deploy-backfill-job
+
+timeout: 3600s

--- a/cloudbuild.frontend-release.yaml
+++ b/cloudbuild.frontend-release.yaml
@@ -1,0 +1,133 @@
+# Automatic frontend-only production release.
+# Invoked by GitHub Actions after required CI succeeds on protected main.
+
+substitutions:
+  _TAG: unset
+  _REGION: us-east1
+  _DOMAIN: voicesthatremain.com
+  _RELEASE_LOCK_BUCKET: letter-archive-485110-release-lock
+  _FRONTEND_IMAGE: '${_REGION}-docker.pkg.dev/${PROJECT_ID}/letter-archive/frontend'
+  _FRONTEND_SERVICE_ACCOUNT: 'letter-archive-frontend@${PROJECT_ID}.iam.gserviceaccount.com'
+
+options:
+  dynamic_substitutions: true
+  logging: CLOUD_LOGGING_ONLY
+
+steps:
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-source
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_BUILD_LOCATION=${_REGION}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+    args:
+      - deploy/cloudrun/verify-build-source.sh
+    waitFor: ['-']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: acquire-release-lock
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_LOCK_BUCKET=${_RELEASE_LOCK_BUCKET}'
+    args:
+      - deploy/cloudrun/acquire-release-lock.sh
+    waitFor: ['verify-source']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-current-main
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+    args:
+      - deploy/cloudrun/verify-current-main.sh
+    waitFor: ['acquire-release-lock']
+
+  - name: gcr.io/cloud-builders/docker
+    id: pull-frontend-cache
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+    args:
+      - -c
+      - docker pull "$$LETTER_ARCHIVE_IMAGE_REPOSITORY:latest" || true
+    waitFor: ['verify-current-main']
+
+  - name: gcr.io/cloud-builders/docker
+    id: build-frontend
+    args:
+      - build
+      - --cache-from
+      - '${_FRONTEND_IMAGE}:latest'
+      - -t
+      - '${_FRONTEND_IMAGE}:${_TAG}'
+      - -t
+      - '${_FRONTEND_IMAGE}:latest'
+      - --build-arg
+      - 'VITE_API_URL=https://api.${_DOMAIN}'
+      - --build-arg
+      - 'VITE_SITE_URL=https://${_DOMAIN}'
+      - --build-arg
+      - 'RELEASE_SHA=${_TAG}'
+      - -f
+      - frontend/Dockerfile
+      - frontend
+    waitFor: ['pull-frontend-cache']
+
+  - name: gcr.io/cloud-builders/docker
+    id: push-frontend
+    args:
+      - push
+      - --all-tags
+      - '${_FRONTEND_IMAGE}'
+    waitFor: ['build-frontend']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: prepare-frontend-manifest
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+      - 'LETTER_ARCHIVE_DOMAIN=${_DOMAIN}'
+      - 'LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+    args:
+      - deploy/cloudrun/prepare-frontend-release-manifest.sh
+    waitFor: ['push-frontend']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: promote-frontend
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_SERVICE=letter-archive-frontend'
+      - 'LETTER_ARCHIVE_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_PRODUCTION_URL=https://${_DOMAIN}'
+      - 'LETTER_ARCHIVE_SERVICE_MANIFEST=rendered/cloudrun/frontend-service.yaml'
+    args:
+      - deploy/cloudrun/promote-service.sh
+    waitFor: ['prepare-frontend-manifest']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: release-production-lock
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_LOCK_BUCKET=${_RELEASE_LOCK_BUCKET}'
+    args:
+      - deploy/cloudrun/release-release-lock.sh
+    waitFor: ['promote-frontend']
+
+timeout: 3600s

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -1,0 +1,185 @@
+# Automatic full production release.
+# Invoked by GitHub Actions after required CI succeeds on protected main.
+# Migration policy fails closed unless production is past the maintenance
+# baseline and every pending migration is explicitly rolling-safe.
+
+substitutions:
+  _TAG: unset
+  _REGION: us-east1
+  _CLOUD_SQL_INSTANCE: letter-archive-db
+  _ARCHIVE_BUCKET: letter-archive-485110-archive
+  _DOMAIN: voicesthatremain.com
+  _RELEASE_LOCK_BUCKET: letter-archive-485110-release-lock
+  _BACKEND_SERVICE_ACCOUNT: 'letter-archive-backend@${PROJECT_ID}.iam.gserviceaccount.com'
+  _FRONTEND_SERVICE_ACCOUNT: 'letter-archive-frontend@${PROJECT_ID}.iam.gserviceaccount.com'
+  _WORKER_SERVICE_ACCOUNT: 'letter-archive-worker@${PROJECT_ID}.iam.gserviceaccount.com'
+  _MIGRATE_SERVICE_ACCOUNT: 'letter-archive-migrate@${PROJECT_ID}.iam.gserviceaccount.com'
+  _BACKFILL_SERVICE_ACCOUNT: 'letter-archive-backfill@${PROJECT_ID}.iam.gserviceaccount.com'
+  _BACKEND_IMAGE: '${_REGION}-docker.pkg.dev/${PROJECT_ID}/letter-archive/backend'
+  _FRONTEND_IMAGE: '${_REGION}-docker.pkg.dev/${PROJECT_ID}/letter-archive/frontend'
+
+options:
+  dynamic_substitutions: true
+  logging: CLOUD_LOGGING_ONLY
+
+steps:
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-source
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_BUILD_LOCATION=${_REGION}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+    args:
+      - deploy/cloudrun/verify-build-source.sh
+    waitFor: ['-']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: acquire-release-lock
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_LOCK_BUCKET=${_RELEASE_LOCK_BUCKET}'
+    args:
+      - deploy/cloudrun/acquire-release-lock.sh
+    waitFor: ['verify-source']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: verify-current-main
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+    args:
+      - deploy/cloudrun/verify-current-main.sh
+    waitFor: ['acquire-release-lock']
+
+  - name: gcr.io/cloud-builders/docker
+    id: pull-backend-cache
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_BACKEND_IMAGE}'
+    args:
+      - -c
+      - docker pull "$$LETTER_ARCHIVE_IMAGE_REPOSITORY:latest" || true
+    waitFor: ['verify-current-main']
+
+  - name: gcr.io/cloud-builders/docker
+    id: pull-frontend-cache
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+    args:
+      - -c
+      - docker pull "$$LETTER_ARCHIVE_IMAGE_REPOSITORY:latest" || true
+    waitFor: ['verify-current-main']
+
+  - name: gcr.io/cloud-builders/docker
+    id: build-backend
+    args:
+      - build
+      - --cache-from
+      - '${_BACKEND_IMAGE}:latest'
+      - -t
+      - '${_BACKEND_IMAGE}:${_TAG}'
+      - -t
+      - '${_BACKEND_IMAGE}:latest'
+      - -f
+      - backend/Dockerfile
+      - backend
+    waitFor: ['pull-backend-cache']
+
+  - name: gcr.io/cloud-builders/docker
+    id: build-frontend
+    args:
+      - build
+      - --cache-from
+      - '${_FRONTEND_IMAGE}:latest'
+      - -t
+      - '${_FRONTEND_IMAGE}:${_TAG}'
+      - -t
+      - '${_FRONTEND_IMAGE}:latest'
+      - --build-arg
+      - 'VITE_API_URL=https://api.${_DOMAIN}'
+      - --build-arg
+      - 'VITE_SITE_URL=https://${_DOMAIN}'
+      - --build-arg
+      - 'RELEASE_SHA=${_TAG}'
+      - -f
+      - frontend/Dockerfile
+      - frontend
+    waitFor: ['pull-frontend-cache']
+
+  - name: gcr.io/cloud-builders/docker
+    id: push-backend
+    args:
+      - push
+      - --all-tags
+      - '${_BACKEND_IMAGE}'
+    waitFor: ['build-backend']
+
+  - name: gcr.io/cloud-builders/docker
+    id: push-frontend
+    args:
+      - push
+      - --all-tags
+      - '${_FRONTEND_IMAGE}'
+    waitFor: ['build-frontend']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: prepare-manifests
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY=${_BACKEND_IMAGE}'
+      - 'LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+      - 'LETTER_ARCHIVE_CLOUD_SQL_INSTANCE=${_CLOUD_SQL_INSTANCE}'
+      - 'LETTER_ARCHIVE_ARCHIVE_BUCKET=${_ARCHIVE_BUCKET}'
+      - 'LETTER_ARCHIVE_DOMAIN=${_DOMAIN}'
+      - 'LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT=${_BACKEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT=${_WORKER_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT=${_MIGRATE_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT=${_BACKFILL_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_MIGRATION_RELEASE_MODE=automatic'
+    args:
+      - deploy/cloudrun/prepare-release-manifests.sh
+    waitFor: ['push-backend', 'push-frontend']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: release-production
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT=${_BACKEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT=${_FRONTEND_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT=${_WORKER_SERVICE_ACCOUNT}'
+      - 'LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY=${_BACKEND_IMAGE}'
+      - 'LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY=${_FRONTEND_IMAGE}'
+      - 'LETTER_ARCHIVE_BACKEND_PRODUCTION_URL=https://api.${_DOMAIN}'
+      - 'LETTER_ARCHIVE_FRONTEND_PRODUCTION_URL=https://${_DOMAIN}'
+    args:
+      - deploy/cloudrun/release-full.sh
+    waitFor: ['prepare-manifests']
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: release-production-lock
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_SHA=${_TAG}'
+      - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
+      - 'LETTER_ARCHIVE_RELEASE_LOCK_BUCKET=${_RELEASE_LOCK_BUCKET}'
+    args:
+      - deploy/cloudrun/release-release-lock.sh
+    waitFor: ['release-production']
+
+timeout: 3600s

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -17,17 +17,44 @@ These templates assume:
 - `backend-migrate-job.yaml` — one-off migration job
 - `frontend-service.yaml` — frontend nginx container
 
-## Required substitutions
+## Manifest rendering
 
-Replace the placeholder values before applying:
+`render-manifests.sh` replaces the templates' collision-resistant `__NAME__`
+placeholders, validates every value, and atomically writes a separate rendered
+directory. It fails without modifying the templates if a value is missing or invalid
+or any placeholder remains. `cloudbuild.deploy.yaml` supplies the required values as
+step environment data during the controlled deployment. Keep environment variable
+names such as `CLOUD_RUN_REGION` outside the placeholder tokens.
 
-- `PROJECT_NUMBER` / `PROJECT_ID`
-- `REGION`
-- `BACKEND_IMAGE` / `FRONTEND_IMAGE`
-- `SERVICE_ACCOUNT_EMAIL`
-- `CLOUD_SQL_INSTANCE`
-- `ARCHIVE_BUCKET`
-- `YOUR_DOMAIN`
+Required render values:
+
+- `LETTER_ARCHIVE_PROJECT_ID`
+- `LETTER_ARCHIVE_REGION`
+- `LETTER_ARCHIVE_BACKEND_IMAGE` / `LETTER_ARCHIVE_FRONTEND_IMAGE`
+- `LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT`
+- `LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT`
+- `LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT`
+- `LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT`
+- `LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT`
+- `LETTER_ARCHIVE_MIGRATION_RELEASE_MODE`
+- `LETTER_ARCHIVE_RELEASE_SHA`
+- `LETTER_ARCHIVE_CLOUD_SQL_INSTANCE`
+- `LETTER_ARCHIVE_ARCHIVE_BUCKET`
+- `LETTER_ARCHIVE_DOMAIN`
+
+## Release lock prerequisite
+
+Before any controlled or automatic production build, create the regional,
+uniform-access bucket `gs://letter-archive-485110-release-lock` in `US-EAST1`
+with public access prevention enforced. Grant
+`letter-archive-build@letter-archive-485110.iam.gserviceaccount.com` object
+create, read, and delete access on this bucket only (for example,
+bucket-scoped `roles/storage.objectAdmin`).
+
+The three production build configurations fail closed without this bucket.
+Their scripts use object-generation preconditions so only one build owns the
+lock and only the observed generation can be reaped or released. Do not replace
+those operations with unconditional object writes or deletes.
 
 ## Secrets
 
@@ -37,12 +64,24 @@ Store sensitive values in Secret Manager and reference them in YAML:
 gcloud secrets create jwt-secret --replication-policy="automatic"
 echo -n "your-random-secret" | gcloud secrets versions add jwt-secret --data-file=-
 
-gcloud secrets create database-url --replication-policy="automatic"
-echo -n "postgresql://..." | gcloud secrets versions add database-url --data-file=-
+gcloud secrets create database-url-api --replication-policy="automatic"
+gcloud secrets create database-url-worker --replication-policy="automatic"
+gcloud secrets create database-url-migrate --replication-policy="automatic"
+gcloud secrets create database-url-backfill --replication-policy="automatic"
 
 gcloud secrets create openai-api-key --replication-policy="automatic"
 echo -n "sk-..." | gcloud secrets versions add openai-api-key --data-file=-
 ```
+
+Add each database URL as a secret version without writing it to shell history.
+The API and worker database roles are DML-only, the migration role owns
+migration-managed objects, and the backfill role is limited to reading and
+updating `letter_pages`. Grant each runtime service account access only to its
+matching secret. The shared legacy `database-url` secret is not used by these
+templates.
+
+The release architecture, identity boundaries, migration policy, and rollback
+behavior are documented in [`docs/deployment.md`](../../docs/deployment.md).
 
 ## Push-time build validation
 
@@ -58,16 +97,13 @@ deployment config. This separation is intentional: migrations 0054/0055 and the
 atomic first-page writer cannot be introduced safely while an older API or worker can
 still write.
 
-## Controlled deployment
+## Controlled baseline deployment
 
-Use `cloudbuild.deploy.yaml` only after an operator has established write quiescence:
+Use `cloudbuild.deploy.yaml` only for the one-time maintenance baseline. The
+operator authorizes a maintenance window; the pipeline then establishes and
+verifies write quiescence itself:
 
-1. Pause administrative writes and uploads.
-2. Pause `letter-archive-worker-reconcile` if that Scheduler job exists.
-3. Stop new worker wakes and drain or terminate every old worker execution.
-4. Drain every old API revision that can write with the pre-0054 contract.
-5. Confirm no old API or worker writer remains.
-6. Fetch `origin/main`, confirm the reviewed commit is the clean local and remote
+1. Fetch `origin/main`, confirm the reviewed commit is the clean local and remote
    `main`, then submit the remote repository pinned to that full commit SHA. This
    prevents a dirty local directory from being uploaded and merely labelled as the
    reviewed commit:
@@ -80,12 +116,18 @@ Use `cloudbuild.deploy.yaml` only after an operator has established write quiesc
    test "$(git rev-parse --verify origin/main)" = "$DEPLOY_SHA"
    DEPLOY_SOURCE="$(git remote get-url origin)"
    gcloud builds submit "$DEPLOY_SOURCE" \
+     --project=letter-archive-485110 \
+     --region=us-east1 \
      --git-source-revision="$DEPLOY_SHA" \
+     --service-account=projects/letter-archive-485110/serviceAccounts/letter-archive-build@letter-archive-485110.iam.gserviceaccount.com \
      --config=cloudbuild.deploy.yaml \
      --substitutions=_TAG="$DEPLOY_SHA",_CONFIRM_WRITE_QUIESCENCE=true
    ```
 
-7. Route 100% of API traffic to the new revision, confirm old revisions are gone,
+2. The build removes public backend invocation, routes traffic to a non-writing
+   maintenance revision, pauses reconciliation if present, verifies no active worker,
+   and waits beyond the old request timeout before migration.
+3. Route 100% of API traffic to the new revision, confirm old revisions are gone,
    perform the migration 0054/upload/manual-worker-wake smoke checks recorded in
    `docs/architecture-cleanup/current-work.md`, and only then reopen administrative
    writes. Keep `letter-archive-worker-reconcile` paused or absent and keep
@@ -93,8 +135,8 @@ Use `cloudbuild.deploy.yaml` only after an operator has established write quiesc
    separate, later proof sequence below.
 
 The deployment graph rejects an omitted confirmation and any `_TAG` that is not a
-full lowercase Git SHA. The acknowledgement is an operator assertion, not an
-automatic drain mechanism.
+full lowercase Git SHA. The confirmation authorizes downtime; the build still has to
+establish and verify the drain before its migration step can start.
 
 The checked-in build keeps scheduled reconciliation disabled by default. This is a
 rollout gate: replacing a Cloud Run Job does not stop an older execution that began

--- a/deploy/cloudrun/acquire-release-lock.sh
+++ b/deploy/cloudrun/acquire-release-lock.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_RELEASE_SHA
+  LETTER_ARCHIVE_BUILD_ID
+  LETTER_ARCHIVE_RELEASE_LOCK_BUCKET
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing release lock value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$LETTER_ARCHIVE_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release SHA must be a full lowercase Git commit SHA" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_BUILD_ID" =~ ^[0-9a-f-]{8,64}$ ]]; then
+  echo "Build ID contains unexpected characters" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_RELEASE_LOCK_BUCKET" =~ ^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$ ]]; then
+  echo "Release lock bucket name is invalid" >&2
+  exit 1
+fi
+
+lock_uri="gs://${LETTER_ARCHIVE_RELEASE_LOCK_BUCKET}/production.lock"
+lock_payload="${LETTER_ARCHIVE_BUILD_ID} ${LETTER_ARCHIVE_RELEASE_SHA}"
+
+for attempt in $(seq 1 180); do
+  if printf '%s\n' "$lock_payload" \
+    | gcloud storage cp - "$lock_uri" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --if-generation-match=0 >/dev/null 2>&1; then
+    echo "Acquired production release lock for build $LETTER_ARCHIVE_BUILD_ID"
+    exit 0
+  fi
+
+  current_payload="$(
+    gcloud storage cat "$lock_uri" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" 2>/dev/null || true
+  )"
+  read -r owner_build_id owner_release_sha extra <<<"$current_payload"
+  if [[ ! "$owner_build_id" =~ ^[0-9a-f-]{8,64}$ ]] \
+    || [[ ! "$owner_release_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ -n "${extra:-}" ]]; then
+    echo "Production release lock has invalid ownership data" >&2
+    exit 1
+  fi
+
+  owner_status="$(
+    gcloud builds describe "$owner_build_id" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --region="$LETTER_ARCHIVE_REGION" \
+      --format='value(status)' 2>/dev/null || true
+  )"
+  case "$owner_status" in
+    PENDING|QUEUED|WORKING)
+      if (( attempt % 6 == 0 )); then
+        echo "Waiting for production release build $owner_build_id ($owner_status)"
+      fi
+      sleep 10
+      ;;
+    SUCCESS|FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)
+      lock_generation="$(
+        gcloud storage objects describe "$lock_uri" \
+          --project="$LETTER_ARCHIVE_PROJECT_ID" \
+          --format='value(generation)'
+      )"
+      if [[ ! "$lock_generation" =~ ^[0-9]+$ ]]; then
+        echo "Production release lock generation is invalid" >&2
+        exit 1
+      fi
+      gcloud storage rm "$lock_uri" \
+        --project="$LETTER_ARCHIVE_PROJECT_ID" \
+        --if-generation-match="$lock_generation" >/dev/null 2>&1 || true
+      ;;
+    *)
+      echo "Cannot prove release lock owner state for build $owner_build_id" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "Timed out waiting for the production release lock" >&2
+exit 1

--- a/deploy/cloudrun/acquire-release-lock.sh
+++ b/deploy/cloudrun/acquire-release-lock.sh
@@ -41,10 +41,28 @@ for attempt in $(seq 1 180); do
     exit 0
   fi
 
-  current_payload="$(
-    gcloud storage cat "$lock_uri" \
-      --project="$LETTER_ARCHIVE_PROJECT_ID" 2>/dev/null || true
-  )"
+  # Read one immutable object version. Fetching the live payload and its
+  # generation separately would allow another contender to replace the lock
+  # between those reads, causing us to delete that contender's live lock.
+  if ! lock_generation="$(
+    gcloud storage objects describe "$lock_uri" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --format='value(generation)' 2>/dev/null
+  )"; then
+    continue
+  fi
+  if [[ ! "$lock_generation" =~ ^[0-9]+$ ]]; then
+    echo "Production release lock generation is invalid" >&2
+    exit 1
+  fi
+  if ! current_payload="$(
+    gcloud storage cat "${lock_uri}#${lock_generation}" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" 2>/dev/null
+  )"; then
+    # The observed generation stopped being readable before its payload was
+    # fetched. Re-observe instead of making a decision about a different lock.
+    continue
+  fi
   read -r owner_build_id owner_release_sha extra <<<"$current_payload"
   if [[ ! "$owner_build_id" =~ ^[0-9a-f-]{8,64}$ ]] \
     || [[ ! "$owner_release_sha" =~ ^[0-9a-f]{40}$ ]] \
@@ -67,15 +85,6 @@ for attempt in $(seq 1 180); do
       sleep 10
       ;;
     SUCCESS|FAILURE|INTERNAL_ERROR|TIMEOUT|CANCELLED|EXPIRED)
-      lock_generation="$(
-        gcloud storage objects describe "$lock_uri" \
-          --project="$LETTER_ARCHIVE_PROJECT_ID" \
-          --format='value(generation)'
-      )"
-      if [[ ! "$lock_generation" =~ ^[0-9]+$ ]]; then
-        echo "Production release lock generation is invalid" >&2
-        exit 1
-      fi
       gcloud storage rm "$lock_uri" \
         --project="$LETTER_ARCHIVE_PROJECT_ID" \
         --if-generation-match="$lock_generation" >/dev/null 2>&1 || true

--- a/deploy/cloudrun/backend-backfill-dimensions-job.yaml
+++ b/deploy/cloudrun/backend-backfill-dimensions-job.yaml
@@ -2,14 +2,14 @@ apiVersion: run.googleapis.com/v1
 kind: Job
 metadata:
   name: letter-archive-backfill-dimensions
-  namespace: PROJECT_NUMBER
+  namespace: __PROJECT_ID__
   labels:
-    cloud.googleapis.com/location: REGION
+    cloud.googleapis.com/location: __REGION__
 spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/cloudsql-instances: PROJECT_ID:REGION:CLOUD_SQL_INSTANCE
+        run.googleapis.com/cloudsql-instances: __PROJECT_ID__:__REGION__:__CLOUD_SQL_INSTANCE__
         run.googleapis.com/execution-environment: gen2
     spec:
       taskCount: 1
@@ -18,9 +18,9 @@ spec:
         spec:
           maxRetries: 0
           timeoutSeconds: 900
-          serviceAccountName: SERVICE_ACCOUNT_EMAIL
+          serviceAccountName: __BACKFILL_SERVICE_ACCOUNT__
           containers:
-            - image: BACKEND_IMAGE
+            - image: __BACKEND_IMAGE__
               command:
                 - node
               args:
@@ -35,7 +35,7 @@ spec:
                 - name: DATABASE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: database-url
+                      name: database-url-backfill
                       key: latest
               resources:
                 limits:
@@ -50,4 +50,4 @@ spec:
                 driver: gcsfuse.run.googleapis.com
                 readOnly: true
                 volumeAttributes:
-                  bucketName: ARCHIVE_BUCKET
+                  bucketName: __ARCHIVE_BUCKET__

--- a/deploy/cloudrun/backend-migrate-job.yaml
+++ b/deploy/cloudrun/backend-migrate-job.yaml
@@ -2,14 +2,14 @@ apiVersion: run.googleapis.com/v1
 kind: Job
 metadata:
   name: letter-archive-migrate
-  namespace: PROJECT_NUMBER
+  namespace: __PROJECT_ID__
   labels:
-    cloud.googleapis.com/location: REGION
+    cloud.googleapis.com/location: __REGION__
 spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/cloudsql-instances: PROJECT_ID:REGION:CLOUD_SQL_INSTANCE
+        run.googleapis.com/cloudsql-instances: __PROJECT_ID__:__REGION__:__CLOUD_SQL_INSTANCE__
     spec:
       taskCount: 1
       parallelism: 1
@@ -17,9 +17,9 @@ spec:
         spec:
           maxRetries: 0
           timeoutSeconds: 900
-          serviceAccountName: SERVICE_ACCOUNT_EMAIL
+          serviceAccountName: __MIGRATE_SERVICE_ACCOUNT__
           containers:
-            - image: BACKEND_IMAGE
+            - image: __BACKEND_IMAGE__
               command:
                 - node
               args:
@@ -29,11 +29,13 @@ spec:
                   value: production
                 - name: LOG_TO_FILES
                   value: "false"
+                - name: MIGRATION_RELEASE_MODE
+                  value: __MIGRATION_RELEASE_MODE__
                 # Secret from Secret Manager
                 - name: DATABASE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: database-url
+                      name: database-url-migrate
                       key: latest
               resources:
                 limits:

--- a/deploy/cloudrun/backend-service.yaml
+++ b/deploy/cloudrun/backend-service.yaml
@@ -2,22 +2,22 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: letter-archive-backend
-  namespace: PROJECT_NUMBER
+  namespace: __PROJECT_ID__
   labels:
-    cloud.googleapis.com/location: REGION
+    cloud.googleapis.com/location: __REGION__
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "5"
-        run.googleapis.com/cloudsql-instances: PROJECT_ID:REGION:CLOUD_SQL_INSTANCE
+        run.googleapis.com/cloudsql-instances: __PROJECT_ID__:__REGION__:__CLOUD_SQL_INSTANCE__
     spec:
       containerConcurrency: 40
       timeoutSeconds: 300
-      serviceAccountName: SERVICE_ACCOUNT_EMAIL
+      serviceAccountName: __BACKEND_SERVICE_ACCOUNT__
       containers:
-        - image: BACKEND_IMAGE
+        - image: __BACKEND_IMAGE__
           ports:
             - name: http1
               containerPort: 8080
@@ -25,9 +25,9 @@ spec:
             - name: NODE_ENV
               value: production
             - name: SITE_URL
-              value: https://YOUR_DOMAIN
+              value: https://__DOMAIN__
             - name: CORS_ORIGINS
-              value: https://YOUR_DOMAIN
+              value: https://__DOMAIN__
             - name: STORAGE_DIR
               value: /mnt/archive
             - name: LOG_TO_FILES
@@ -36,17 +36,19 @@ spec:
               value: "false"
             - name: SEED_DEV_ADMIN
               value: "false"
+            - name: RELEASE_SHA
+              value: __RELEASE_SHA__
             - name: GOOGLE_CLOUD_PROJECT
-              value: PROJECT_ID
+              value: __PROJECT_ID__
             - name: CLOUD_RUN_REGION
-              value: REGION
+              value: __REGION__
             - name: CLOUD_RUN_WORKER_JOB_NAME
               value: letter-archive-worker
             # Secrets from Secret Manager
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: database-url
+                  name: database-url-api
                   key: latest
             - name: JWT_SECRET
               valueFrom:
@@ -64,7 +66,7 @@ spec:
               memory: 1Gi
           startupProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 8080
             failureThreshold: 10
             periodSeconds: 3
@@ -77,7 +79,7 @@ spec:
             driver: gcsfuse.run.googleapis.com
             readOnly: false
             volumeAttributes:
-              bucketName: ARCHIVE_BUCKET
+              bucketName: __ARCHIVE_BUCKET__
   traffic:
     - percent: 100
       latestRevision: true

--- a/deploy/cloudrun/backend-worker-job.yaml
+++ b/deploy/cloudrun/backend-worker-job.yaml
@@ -2,14 +2,14 @@ apiVersion: run.googleapis.com/v1
 kind: Job
 metadata:
   name: letter-archive-worker
-  namespace: PROJECT_NUMBER
+  namespace: __PROJECT_ID__
   labels:
-    cloud.googleapis.com/location: REGION
+    cloud.googleapis.com/location: __REGION__
 spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/cloudsql-instances: PROJECT_ID:REGION:CLOUD_SQL_INSTANCE
+        run.googleapis.com/cloudsql-instances: __PROJECT_ID__:__REGION__:__CLOUD_SQL_INSTANCE__
     spec:
       taskCount: 1
       parallelism: 1
@@ -18,9 +18,9 @@ spec:
           # Keep Cloud Run's default retry budget; fenced claims make retries safe.
           maxRetries: 3
           timeoutSeconds: 3600
-          serviceAccountName: SERVICE_ACCOUNT_EMAIL
+          serviceAccountName: __WORKER_SERVICE_ACCOUNT__
           containers:
-            - image: BACKEND_IMAGE
+            - image: __BACKEND_IMAGE__
               command:
                 - node
               args:
@@ -39,16 +39,16 @@ spec:
                 - name: SEED_DEV_ADMIN
                   value: "false"
                 - name: GOOGLE_CLOUD_PROJECT
-                  value: PROJECT_ID
+                  value: __PROJECT_ID__
                 - name: CLOUD_RUN_REGION
-                  value: REGION
+                  value: __REGION__
                 - name: CLOUD_RUN_WORKER_JOB_NAME
                   value: letter-archive-worker
                 # Secrets from Secret Manager
                 - name: DATABASE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: database-url
+                      name: database-url-worker
                       key: latest
                 - name: OPENAI_API_KEY
                   valueFrom:
@@ -68,4 +68,4 @@ spec:
                 driver: gcsfuse.run.googleapis.com
                 readOnly: false
                 volumeAttributes:
-                  bucketName: ARCHIVE_BUCKET
+                  bucketName: __ARCHIVE_BUCKET__

--- a/deploy/cloudrun/frontend-service.yaml
+++ b/deploy/cloudrun/frontend-service.yaml
@@ -2,9 +2,9 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: letter-archive-frontend
-  namespace: PROJECT_NUMBER
+  namespace: __PROJECT_ID__
   labels:
-    cloud.googleapis.com/location: REGION
+    cloud.googleapis.com/location: __REGION__
 spec:
   template:
     metadata:
@@ -14,9 +14,9 @@ spec:
     spec:
       containerConcurrency: 80
       timeoutSeconds: 60
-      serviceAccountName: SERVICE_ACCOUNT_EMAIL
+      serviceAccountName: __FRONTEND_SERVICE_ACCOUNT__
       containers:
-        - image: FRONTEND_IMAGE
+        - image: __FRONTEND_IMAGE__
           ports:
             - name: http1
               containerPort: 8080

--- a/deploy/cloudrun/prepare-candidate-manifest.sh
+++ b/deploy/cloudrun/prepare-candidate-manifest.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source_manifest="${1:-}"
+candidate_manifest="${2:-}"
+
+: "${LETTER_ARCHIVE_SERVICE:?Missing LETTER_ARCHIVE_SERVICE}"
+: "${LETTER_ARCHIVE_PREVIOUS_REVISION:?Missing LETTER_ARCHIVE_PREVIOUS_REVISION}"
+: "${LETTER_ARCHIVE_CANDIDATE_REVISION:?Missing LETTER_ARCHIVE_CANDIDATE_REVISION}"
+: "${LETTER_ARCHIVE_CANDIDATE_TAG:?Missing LETTER_ARCHIVE_CANDIDATE_TAG}"
+
+name_pattern='^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$'
+for value in \
+  "$LETTER_ARCHIVE_SERVICE" \
+  "$LETTER_ARCHIVE_PREVIOUS_REVISION" \
+  "$LETTER_ARCHIVE_CANDIDATE_REVISION" \
+  "$LETTER_ARCHIVE_CANDIDATE_TAG"; do
+  if [[ ! "$value" =~ $name_pattern ]]; then
+    echo "Invalid Cloud Run candidate manifest name: $value" >&2
+    exit 1
+  fi
+done
+if (( ${#LETTER_ARCHIVE_SERVICE} + 1 + ${#LETTER_ARCHIVE_CANDIDATE_TAG} > 46 )); then
+  echo "Cloud Run service and candidate tag exceed the combined length limit" >&2
+  exit 1
+fi
+if [[ ! -f "$source_manifest" || -z "$candidate_manifest" ]]; then
+  echo "Candidate manifest source or destination is invalid" >&2
+  exit 1
+fi
+if [[ -e "$candidate_manifest" ]]; then
+  echo "Candidate manifest destination already exists" >&2
+  exit 1
+fi
+
+awk \
+  -v service="$LETTER_ARCHIVE_SERVICE" \
+  -v previous="$LETTER_ARCHIVE_PREVIOUS_REVISION" \
+  -v candidate="$LETTER_ARCHIVE_CANDIDATE_REVISION" \
+  -v tag="$LETTER_ARCHIVE_CANDIDATE_TAG" '
+  BEGIN {
+    template_seen = 0
+    revision_insertions = 0
+    traffic_blocks = 0
+    skipping_traffic = 0
+  }
+  $0 == "  template:" {
+    template_seen = 1
+    print
+    next
+  }
+  template_seen == 1 && revision_insertions == 0 && $0 == "    metadata:" {
+    print
+    print "      name: " candidate
+    revision_insertions++
+    next
+  }
+  $0 == "  traffic:" {
+    traffic_blocks++
+    skipping_traffic = 1
+    print "  traffic:"
+    print "    - revisionName: " previous
+    print "      percent: 100"
+    print "    - revisionName: " candidate
+    print "      percent: 0"
+    print "      tag: " tag
+    next
+  }
+  skipping_traffic == 1 { next }
+  { print }
+  END {
+    if (revision_insertions != 1 || traffic_blocks != 1) {
+      print "Service manifest did not have the expected template/traffic structure" > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$source_manifest" > "$candidate_manifest"
+
+if ! grep -qx "  name: ${LETTER_ARCHIVE_SERVICE}" "$candidate_manifest"; then
+  echo "Candidate manifest service identity changed unexpectedly" >&2
+  exit 1
+fi

--- a/deploy/cloudrun/prepare-frontend-release-manifest.sh
+++ b/deploy/cloudrun/prepare-frontend-release-manifest.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_RELEASE_SHA
+  LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_DOMAIN
+  LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing frontend release manifest value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+tagged_image="${LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY}:${LETTER_ARCHIVE_RELEASE_SHA}"
+digest="$(
+  gcloud artifacts docker images describe "$tagged_image" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --format='value(image_summary.digest)'
+)"
+if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "Could not resolve an immutable frontend digest" >&2
+  exit 1
+fi
+export LETTER_ARCHIVE_FRONTEND_IMAGE="${LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY}@${digest}"
+
+bash deploy/cloudrun/render-manifests.sh \
+  deploy/cloudrun rendered/cloudrun frontend-service.yaml

--- a/deploy/cloudrun/prepare-release-manifests.sh
+++ b/deploy/cloudrun/prepare-release-manifests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_RELEASE_SHA
+  LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_CLOUD_SQL_INSTANCE
+  LETTER_ARCHIVE_ARCHIVE_BUCKET
+  LETTER_ARCHIVE_DOMAIN
+  LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_MIGRATION_RELEASE_MODE
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing release manifest value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+resolve_digest_reference() {
+  local image_repository="$1"
+  local tagged_image="${image_repository}:${LETTER_ARCHIVE_RELEASE_SHA}"
+  local digest
+
+  digest="$(
+    gcloud artifacts docker images describe "$tagged_image" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --format='value(image_summary.digest)'
+  )"
+  if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "Could not resolve an immutable digest for $tagged_image" >&2
+    exit 1
+  fi
+  printf '%s@%s' "$image_repository" "$digest"
+}
+
+export LETTER_ARCHIVE_BACKEND_IMAGE="$(
+  resolve_digest_reference "$LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY"
+)"
+export LETTER_ARCHIVE_FRONTEND_IMAGE="$(
+  resolve_digest_reference "$LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY"
+)"
+
+bash deploy/cloudrun/render-manifests.sh \
+  deploy/cloudrun rendered/cloudrun

--- a/deploy/cloudrun/promote-service.sh
+++ b/deploy/cloudrun/promote-service.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_SERVICE
+  LETTER_ARCHIVE_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_RELEASE_SHA
+  LETTER_ARCHIVE_BUILD_ID
+  LETTER_ARCHIVE_PRODUCTION_URL
+  LETTER_ARCHIVE_SERVICE_MANIFEST
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing service promotion value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$LETTER_ARCHIVE_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release SHA must be a full lowercase Git commit SHA" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_BUILD_ID" =~ ^[0-9a-f-]{8,64}$ ]]; then
+  echo "Build ID contains unexpected characters" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_PROJECT_ID" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+  echo "Project ID is invalid" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_REGION" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]]; then
+  echo "Region is invalid" >&2
+  exit 1
+fi
+service_account_pattern="^[a-z][a-z0-9-]{4,28}[a-z0-9]@${LETTER_ARCHIVE_PROJECT_ID}\\.iam\\.gserviceaccount\\.com$"
+if [[ ! "$LETTER_ARCHIVE_SERVICE_ACCOUNT" =~ $service_account_pattern ]]; then
+  echo "Service account is invalid for the release project" >&2
+  exit 1
+fi
+image_repository_pattern="^${LETTER_ARCHIVE_REGION}-docker\\.pkg\\.dev/${LETTER_ARCHIVE_PROJECT_ID}/[a-z0-9._-]+/[a-z0-9._/-]+$"
+if [[ ! "$LETTER_ARCHIVE_IMAGE_REPOSITORY" =~ $image_repository_pattern ]]; then
+  echo "Image repository is invalid for the release project and region" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_PRODUCTION_URL" =~ ^https://[a-z0-9.-]+$ ]]; then
+  echo "Production URL is invalid" >&2
+  exit 1
+fi
+if [[ ! -f "$LETTER_ARCHIVE_SERVICE_MANIFEST" ]]; then
+  echo "Rendered service manifest is missing" >&2
+  exit 1
+fi
+case "$LETTER_ARCHIVE_SERVICE" in
+  letter-archive-backend|letter-archive-frontend) ;;
+  *)
+    echo "Unsupported Letter Archive service: $LETTER_ARCHIVE_SERVICE" >&2
+    exit 1
+    ;;
+esac
+
+tagged_image="${LETTER_ARCHIVE_IMAGE_REPOSITORY}:${LETTER_ARCHIVE_RELEASE_SHA}"
+image_digest="$(
+  gcloud artifacts docker images describe "$tagged_image" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --format='value(image_summary.digest)'
+)"
+if [[ ! "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "Could not resolve an immutable digest for $tagged_image" >&2
+  exit 1
+fi
+image_reference="${LETTER_ARCHIVE_IMAGE_REPOSITORY}@${image_digest}"
+if ! grep -Fqx "        - image: ${image_reference}" \
+  "$LETTER_ARCHIVE_SERVICE_MANIFEST"; then
+  echo "Rendered service manifest does not contain the release image digest" >&2
+  exit 1
+fi
+if ! grep -Fqx "      serviceAccountName: ${LETTER_ARCHIVE_SERVICE_ACCOUNT}" \
+  "$LETTER_ARCHIVE_SERVICE_MANIFEST"; then
+  echo "Rendered service manifest does not contain the release identity" >&2
+  exit 1
+fi
+
+service_state="$(
+  gcloud run services describe "$LETTER_ARCHIVE_SERVICE" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format=json
+)"
+previous_revision="$(
+  python3 -c '
+import json
+import sys
+state = json.load(sys.stdin)
+traffic = [
+    item for item in state.get("status", {}).get("traffic", [])
+    if int(item.get("percent", 0)) > 0
+]
+if len(traffic) != 1 or int(traffic[0].get("percent", 0)) != 100:
+    raise SystemExit("service must have exactly one 100% traffic revision")
+revision = traffic[0].get("revisionName")
+if not revision:
+    raise SystemExit("serving revision name is missing")
+print(revision)
+' <<<"$service_state"
+)"
+
+release_prefix="${LETTER_ARCHIVE_RELEASE_SHA:0:10}"
+tag_release_prefix="${LETTER_ARCHIVE_RELEASE_SHA:0:8}"
+build_prefix="${LETTER_ARCHIVE_BUILD_ID:0:8}"
+candidate_tag="c-${tag_release_prefix}-${build_prefix}"
+candidate_revision="${LETTER_ARCHIVE_SERVICE}-r-${release_prefix}-${build_prefix}"
+candidate_manifest="${LETTER_ARCHIVE_SERVICE_MANIFEST%.yaml}.candidate.yaml"
+export LETTER_ARCHIVE_PREVIOUS_REVISION="$previous_revision"
+export LETTER_ARCHIVE_CANDIDATE_REVISION="$candidate_revision"
+export LETTER_ARCHIVE_CANDIDATE_TAG="$candidate_tag"
+bash deploy/cloudrun/prepare-candidate-manifest.sh \
+  "$LETTER_ARCHIVE_SERVICE_MANIFEST" "$candidate_manifest"
+
+probe_backend_once() {
+  local base_url="$1"
+  local health
+  health="$(curl --connect-timeout 3 --max-time 10 -fsS \
+    "${base_url}/health")" || return 1
+  [[ "$health" == \
+    "{\"ok\":true,\"releaseSha\":\"${LETTER_ARCHIVE_RELEASE_SHA}\"}" ]] \
+    || return 1
+  curl --connect-timeout 3 --max-time 10 -fsS \
+    "${base_url}/health/ready" >/dev/null \
+    && curl --connect-timeout 3 --max-time 10 -fsS \
+      "${base_url}/auth/status" >/dev/null
+}
+
+probe_frontend_once() {
+  local base_url="$1"
+  local version
+  version="$(curl --connect-timeout 3 --max-time 10 -fsS \
+    "${base_url}/version.json")" || return 1
+  [[ "$version" == \
+    "{\"releaseSha\":\"${LETTER_ARCHIVE_RELEASE_SHA}\"}" ]] \
+    || return 1
+  curl --connect-timeout 3 --max-time 10 -fsS \
+    "${base_url}/admin-login" >/dev/null
+}
+
+wait_for_release_probe() {
+  local base_url="$1"
+  for attempt in $(seq 1 24); do
+    if [[ "$LETTER_ARCHIVE_SERVICE" == letter-archive-backend ]]; then
+      if probe_backend_once "$base_url"; then return 0; fi
+    elif probe_frontend_once "$base_url"; then
+      return 0
+    fi
+    if (( attempt % 6 == 0 )); then
+      echo "Waiting for $LETTER_ARCHIVE_SERVICE release identity ($attempt/24)"
+    fi
+    sleep 5
+  done
+  echo "Release identity probe failed for $base_url" >&2
+  return 1
+}
+
+probe_restored_service() {
+  if [[ "$LETTER_ARCHIVE_SERVICE" == letter-archive-backend ]]; then
+    curl --connect-timeout 3 --max-time 10 -fsS \
+      "${LETTER_ARCHIVE_PRODUCTION_URL}/health" >/dev/null \
+      && curl --connect-timeout 3 --max-time 10 -fsS \
+        "${LETTER_ARCHIVE_PRODUCTION_URL}/health/ready" >/dev/null \
+      && curl --connect-timeout 3 --max-time 10 -fsS \
+        "${LETTER_ARCHIVE_PRODUCTION_URL}/auth/status" >/dev/null
+  else
+    curl --connect-timeout 3 --max-time 10 -fsS \
+      "${LETTER_ARCHIVE_PRODUCTION_URL}/admin-login" >/dev/null
+  fi
+}
+
+traffic_is_restored() {
+  gcloud run services describe "$LETTER_ARCHIVE_SERVICE" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format=json \
+    | python3 -c '
+import json
+import sys
+expected = sys.argv[1]
+state = json.load(sys.stdin)
+traffic = [
+    item for item in state.get("status", {}).get("traffic", [])
+    if int(item.get("percent", 0)) > 0
+]
+if len(traffic) != 1:
+    raise SystemExit(1)
+item = traffic[0]
+if item.get("revisionName") != expected or int(item.get("percent", 0)) != 100:
+    raise SystemExit(1)
+' "$previous_revision"
+}
+
+candidate_created=false
+promoted=false
+
+cleanup_failed_candidate() {
+  local exit_code="$?"
+  trap - EXIT
+  if [[ "$exit_code" -eq 0 ]]; then return; fi
+
+  if [[ "$promoted" == true ]]; then
+    echo "Release failed after promotion; restoring $previous_revision" >&2
+    rollback_complete=false
+    for attempt in $(seq 1 10); do
+      gcloud run services update-traffic "$LETTER_ARCHIVE_SERVICE" \
+        --project="$LETTER_ARCHIVE_PROJECT_ID" \
+        --region="$LETTER_ARCHIVE_REGION" \
+        --to-revisions="${previous_revision}=100" \
+        --remove-tags="$candidate_tag" \
+        --quiet || true
+      if traffic_is_restored && probe_restored_service; then
+        rollback_complete=true
+        break
+      fi
+      sleep 3
+    done
+    if [[ "$rollback_complete" != true ]]; then
+      echo "CRITICAL: production traffic rollback could not be verified" >&2
+      exit 70
+    fi
+  elif [[ "$candidate_created" == true ]]; then
+    tag_removed=false
+    for attempt in 1 2 3; do
+      if gcloud run services update-traffic "$LETTER_ARCHIVE_SERVICE" \
+        --project="$LETTER_ARCHIVE_PROJECT_ID" \
+        --region="$LETTER_ARCHIVE_REGION" \
+        --remove-tags="$candidate_tag" \
+        --quiet; then
+        tag_removed=true
+        break
+      fi
+      sleep "$attempt"
+    done
+    if [[ "$tag_removed" != true ]]; then
+      echo "CRITICAL: failed candidate tag could not be removed" >&2
+      exit 71
+    fi
+  fi
+  exit "$exit_code"
+}
+trap cleanup_failed_candidate EXIT
+
+gcloud run services replace "$candidate_manifest" \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --quiet
+candidate_created=true
+
+service_state="$(
+  gcloud run services describe "$LETTER_ARCHIVE_SERVICE" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format=json
+)"
+candidate_url="$(
+  python3 -c '
+import json
+import sys
+tag = sys.argv[1]
+revision = sys.argv[2]
+state = json.load(sys.stdin)
+matches = [
+    item for item in state.get("status", {}).get("traffic", [])
+    if item.get("tag") == tag and item.get("revisionName") == revision
+]
+if len(matches) != 1 or not matches[0].get("url"):
+    raise SystemExit("candidate URL was not published")
+print(matches[0]["url"])
+' "$candidate_tag" "$candidate_revision" <<<"$service_state"
+)"
+
+wait_for_release_probe "$candidate_url"
+
+promoted=true
+gcloud run services update-traffic "$LETTER_ARCHIVE_SERVICE" \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --to-tags="${candidate_tag}=100" \
+  --quiet
+
+wait_for_release_probe "$LETTER_ARCHIVE_PRODUCTION_URL"
+
+gcloud run services update-traffic "$LETTER_ARCHIVE_SERVICE" \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --to-revisions="${candidate_revision}=100" \
+  --remove-tags="$candidate_tag" \
+  --quiet
+
+ensure_job_invoker() {
+  local service_account="$1"
+  for attempt in 1 2 3; do
+    gcloud run jobs add-iam-policy-binding "$LETTER_ARCHIVE_WORKER_JOB_NAME" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --region="$LETTER_ARCHIVE_REGION" \
+      --member="serviceAccount:${service_account}" \
+      --role=roles/run.invoker \
+      --quiet || true
+    if gcloud run jobs get-iam-policy "$LETTER_ARCHIVE_WORKER_JOB_NAME" \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --region="$LETTER_ARCHIVE_REGION" \
+      --format=json \
+      | LETTER_ARCHIVE_EXPECTED_MEMBER="serviceAccount:${service_account}" \
+        python3 -c '
+import json
+import os
+import sys
+policy = json.load(sys.stdin)
+expected = os.environ["LETTER_ARCHIVE_EXPECTED_MEMBER"]
+for binding in policy.get("bindings", []):
+    if binding.get("role") == "roles/run.invoker" and expected in binding.get("members", []):
+        raise SystemExit(0)
+raise SystemExit(1)
+'; then
+      return 0
+    fi
+    sleep "$attempt"
+  done
+  return 1
+}
+
+if [[ "$LETTER_ARCHIVE_SERVICE" == letter-archive-backend ]]; then
+  : "${LETTER_ARCHIVE_WORKER_JOB_NAME:?Missing LETTER_ARCHIVE_WORKER_JOB_NAME}"
+  : "${LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT:?Missing LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT}"
+  # Restore worker self-handoff first. The backend remains unable to launch a
+  # writer until its own binding is the final committed cutover action.
+  ensure_job_invoker "$LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT"
+  ensure_job_invoker "$LETTER_ARCHIVE_SERVICE_ACCOUNT"
+fi
+
+promoted=false
+candidate_created=false
+trap - EXIT
+echo "Promoted $LETTER_ARCHIVE_SERVICE revision $candidate_revision"

--- a/deploy/cloudrun/quiesce-production.sh
+++ b/deploy/cloudrun/quiesce-production.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_RELEASE_SHA
+  LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_BUILD_ID
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing production quiescence value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$LETTER_ARCHIVE_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release SHA must be a full lowercase Git commit SHA" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_BUILD_ID" =~ ^[0-9a-f-]{8,64}$ ]]; then
+  echo "Build ID contains unexpected characters" >&2
+  exit 1
+fi
+
+tagged_frontend="$(
+  printf '%s:%s' \
+    "$LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY" \
+    "$LETTER_ARCHIVE_RELEASE_SHA"
+)"
+frontend_digest="$(
+  gcloud artifacts docker images describe "$tagged_frontend" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --format='value(image_summary.digest)'
+)"
+if [[ ! "$frontend_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "Could not resolve the maintenance image digest" >&2
+  exit 1
+fi
+maintenance_image="${LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY}@${frontend_digest}"
+
+# Pause scheduled reconciliation before revoking direct wake authority.
+if gcloud services list \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --enabled \
+  --filter='config.name=cloudscheduler.googleapis.com' \
+  --format='value(config.name)' \
+  | grep -qx 'cloudscheduler.googleapis.com'; then
+  if gcloud scheduler jobs describe letter-archive-worker-reconcile \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --location="$LETTER_ARCHIVE_REGION" >/dev/null 2>&1; then
+    gcloud scheduler jobs pause letter-archive-worker-reconcile \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --location="$LETTER_ARCHIVE_REGION" \
+      --quiet
+  fi
+fi
+
+# Revoke the old backend's wake and the old worker's exit-handoff authority
+# before draining requests. Either path could otherwise launch another writer
+# near the end of Cloud Run's request-drain window.
+worker_job="$(
+  gcloud run jobs list \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --filter='metadata.name=letter-archive-worker' \
+    --format='value(metadata.name)'
+)"
+if [[ -n "$worker_job" ]]; then
+  for service_account in \
+    "$LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT" \
+    "$LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT"; do
+    gcloud run jobs remove-iam-policy-binding letter-archive-worker \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --region="$LETTER_ARCHIVE_REGION" \
+      --member="serviceAccount:${service_account}" \
+      --role=roles/run.invoker \
+      --quiet || true
+  done
+
+  gcloud run jobs get-iam-policy letter-archive-worker \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format=json \
+    | LETTER_ARCHIVE_BACKEND_MEMBER="serviceAccount:${LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT}" \
+      LETTER_ARCHIVE_WORKER_MEMBER="serviceAccount:${LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT}" \
+      python3 -c '
+import json
+import os
+import sys
+policy = json.load(sys.stdin)
+for binding in policy.get("bindings", []):
+    if binding.get("role") != "roles/run.invoker":
+        continue
+    members = set(binding.get("members", []))
+    if os.environ["LETTER_ARCHIVE_BACKEND_MEMBER"] in members:
+        raise SystemExit("backend can still invoke the worker job")
+    if os.environ["LETTER_ARCHIVE_WORKER_MEMBER"] in members:
+        raise SystemExit("worker can still hand off to another execution")
+'
+fi
+
+# Block new unauthenticated API requests before moving traffic. Ignore a
+# missing binding only if the policy read below proves public invocation is off.
+gcloud run services remove-iam-policy-binding letter-archive-backend \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --member=allUsers \
+  --role=roles/run.invoker \
+  --quiet || true
+
+gcloud run services get-iam-policy letter-archive-backend \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --format=json \
+  | python3 -c '
+import json
+import sys
+policy = json.load(sys.stdin)
+public = {"allUsers", "allAuthenticatedUsers"}
+for binding in policy.get("bindings", []):
+    if binding.get("role") != "roles/run.invoker":
+        continue
+    if public.intersection(binding.get("members", [])):
+        raise SystemExit("backend still has a public invoker binding")
+'
+
+# Use the already-built static frontend image as a maintenance revision. Clear
+# backend-only configuration so this revision cannot reach the database,
+# secrets, archive bucket, or worker job.
+maintenance_suffix="maintenance-${LETTER_ARCHIVE_RELEASE_SHA:0:8}-${LETTER_ARCHIVE_BUILD_ID:0:8}"
+gcloud run deploy letter-archive-backend \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --image="$maintenance_image" \
+  --service-account="$LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT" \
+  --revision-suffix="$maintenance_suffix" \
+  --no-traffic \
+  --clear-env-vars \
+  --clear-secrets \
+  --clear-cloudsql-instances \
+  --clear-volume-mounts \
+  --clear-volumes \
+  --startup-probe="" \
+  --port=8080 \
+  --quiet
+
+maintenance_revision="$(
+  gcloud run services describe letter-archive-backend \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format='value(status.latestCreatedRevisionName)'
+)"
+if [[ "$maintenance_revision" != \
+  "letter-archive-backend-${maintenance_suffix}" ]]; then
+  echo "Unexpected maintenance revision: $maintenance_revision" >&2
+  exit 1
+fi
+
+gcloud run services update-traffic letter-archive-backend \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --to-revisions="${maintenance_revision}=100" \
+  --quiet
+
+legacy_pool="$(
+  gcloud beta run worker-pools list \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --filter='metadata.name=letter-archive-worker' \
+    --format='value(metadata.name)'
+)"
+if [[ -n "$legacy_pool" ]]; then
+  gcloud beta run worker-pools delete letter-archive-worker \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --quiet
+fi
+
+# Cloud Run traffic transitions are not instantaneous. Wait longer than the
+# old backend's 300-second request timeout so every pre-maintenance request has
+# finished before the incompatible migration begins.
+for interval in $(seq 1 31); do
+  if (( interval % 6 == 0 )); then
+    echo "Waiting for pre-maintenance API requests to drain ($interval/31)"
+  fi
+  sleep 10
+done
+
+# With every worker wake path disabled and old API requests drained, require
+# worker executions to finish before allowing the migration step to start.
+if [[ -n "$worker_job" ]]; then
+  worker_drained=false
+  zero_observations=0
+  for interval in $(seq 1 30); do
+    active_executions="$(
+      gcloud run jobs executions list \
+        --project="$LETTER_ARCHIVE_PROJECT_ID" \
+        --region="$LETTER_ARCHIVE_REGION" \
+        --job=letter-archive-worker \
+        --format=json \
+        | python3 -c '
+import json
+import sys
+executions = json.load(sys.stdin)
+active = [
+    item.get("metadata", {}).get("name", "unknown")
+    for item in executions
+    if not item.get("status", {}).get("completionTime")
+]
+print("\n".join(active))
+'
+    )"
+    if [[ -z "$active_executions" ]]; then
+      zero_observations="$((zero_observations + 1))"
+      if [[ "$zero_observations" -ge 2 ]]; then
+        worker_drained=true
+        break
+      fi
+    else
+      zero_observations=0
+    fi
+    if (( interval % 6 == 0 )); then
+      echo "Waiting for active worker executions to drain ($interval/30)"
+      echo "$active_executions"
+    fi
+    sleep 10
+  done
+  if [[ "$worker_drained" != "true" ]]; then
+    echo "Active worker executions did not drain before migration:" >&2
+    echo "$active_executions" >&2
+    exit 1
+  fi
+fi
+
+echo "Letter Archive production writers are quiescent"

--- a/deploy/cloudrun/release-full.sh
+++ b/deploy/cloudrun/release-full.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_RELEASE_SHA
+  LETTER_ARCHIVE_BUILD_ID
+  LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT
+  LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY
+  LETTER_ARCHIVE_BACKEND_PRODUCTION_URL
+  LETTER_ARCHIVE_FRONTEND_PRODUCTION_URL
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing full release value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+worker_job=letter-archive-worker
+backfill_job=letter-archive-backfill-dimensions
+state_directory="rendered/release-state"
+if [[ -e "$state_directory" ]]; then
+  echo "Release state directory already exists" >&2
+  exit 1
+fi
+mkdir -p "$state_directory"
+
+snapshot_job() {
+  local job_name="$1"
+  local output_path="$2"
+  gcloud run jobs describe "$job_name" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format=export > "$output_path"
+}
+
+job_image() {
+  local job_name="$1"
+  gcloud run jobs describe "$job_name" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format='value(spec.template.spec.template.spec.containers[0].image)'
+}
+
+snapshot_job "$worker_job" "$state_directory/worker.yaml"
+snapshot_job "$backfill_job" "$state_directory/backfill.yaml"
+previous_worker_image="$(job_image "$worker_job")"
+previous_backfill_image="$(job_image "$backfill_job")"
+if [[ -z "$previous_worker_image" || -z "$previous_backfill_image" ]]; then
+  echo "Could not snapshot the previous job images" >&2
+  exit 1
+fi
+gcloud run jobs get-iam-policy "$worker_job" \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --format=json > "$state_directory/worker-policy.json"
+
+scheduler_exists=false
+scheduler_was_enabled=false
+if gcloud services list \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --enabled \
+  --filter='config.name=cloudscheduler.googleapis.com' \
+  --format='value(config.name)' \
+  | grep -qx 'cloudscheduler.googleapis.com'; then
+  if scheduler_state="$(
+    gcloud scheduler jobs describe letter-archive-worker-reconcile \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --location="$LETTER_ARCHIVE_REGION" \
+      --format='value(state)' 2>/dev/null
+  )"; then
+    scheduler_exists=true
+    if [[ "$scheduler_state" == ENABLED ]]; then
+      scheduler_was_enabled=true
+    fi
+  fi
+fi
+
+rollback_jobs=false
+backend_committed=false
+
+resume_scheduler() {
+  if [[ "$scheduler_was_enabled" != true ]]; then
+    return 0
+  fi
+  for attempt in $(seq 1 10); do
+    gcloud scheduler jobs resume letter-archive-worker-reconcile \
+      --project="$LETTER_ARCHIVE_PROJECT_ID" \
+      --location="$LETTER_ARCHIVE_REGION" \
+      --quiet || true
+    scheduler_state="$(
+      gcloud scheduler jobs describe letter-archive-worker-reconcile \
+        --project="$LETTER_ARCHIVE_PROJECT_ID" \
+        --location="$LETTER_ARCHIVE_REGION" \
+        --format='value(state)' 2>/dev/null || true
+    )"
+    if [[ "$scheduler_state" == ENABLED ]]; then
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
+}
+
+restore_release_jobs() {
+  local exit_code="$?"
+  trap - EXIT
+  if [[ "$exit_code" -eq 0 || "$rollback_jobs" != true ]]; then
+    exit "$exit_code"
+  fi
+
+  if [[ "$backend_committed" == true ]]; then
+    if ! resume_scheduler; then
+      echo "CRITICAL: new backend is live but Scheduler could not be resumed" >&2
+      exit 73
+    fi
+    exit "$exit_code"
+  fi
+
+  echo "Restoring pre-release worker and backfill job definitions" >&2
+  restore_complete=true
+  gcloud run jobs replace "$state_directory/worker.yaml" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --quiet || restore_complete=false
+  gcloud run jobs replace "$state_directory/backfill.yaml" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --quiet || restore_complete=false
+  gcloud run jobs set-iam-policy "$worker_job" \
+    "$state_directory/worker-policy.json" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --quiet || restore_complete=false
+
+  if [[ "$(job_image "$worker_job" 2>/dev/null || true)" \
+    != "$previous_worker_image" ]]; then
+    restore_complete=false
+  fi
+  if [[ "$(job_image "$backfill_job" 2>/dev/null || true)" \
+    != "$previous_backfill_image" ]]; then
+    restore_complete=false
+  fi
+  if [[ "$scheduler_was_enabled" == true ]]; then
+    resume_scheduler || restore_complete=false
+  fi
+
+  if [[ "$restore_complete" != true ]]; then
+    echo "CRITICAL: failed to restore the pre-release background jobs" >&2
+    exit 72
+  fi
+  exit "$exit_code"
+}
+trap restore_release_jobs EXIT
+
+gcloud run jobs replace rendered/cloudrun/backend-migrate-job.yaml \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --quiet
+gcloud run jobs execute letter-archive-migrate \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --wait
+
+rollback_jobs=true
+if [[ "$scheduler_was_enabled" == true ]]; then
+  gcloud scheduler jobs pause letter-archive-worker-reconcile \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --location="$LETTER_ARCHIVE_REGION" \
+    --quiet
+fi
+
+for service_account in \
+  "$LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT" \
+  "$LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT"; do
+  gcloud run jobs remove-iam-policy-binding "$worker_job" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --member="serviceAccount:${service_account}" \
+    --role=roles/run.invoker \
+    --quiet || true
+done
+
+gcloud run jobs get-iam-policy "$worker_job" \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --format=json \
+  | LETTER_ARCHIVE_BACKEND_MEMBER="serviceAccount:${LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT}" \
+    LETTER_ARCHIVE_WORKER_MEMBER="serviceAccount:${LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT}" \
+    python3 -c '
+import json
+import os
+import sys
+policy = json.load(sys.stdin)
+for binding in policy.get("bindings", []):
+    if binding.get("role") != "roles/run.invoker":
+        continue
+    members = set(binding.get("members", []))
+    if os.environ["LETTER_ARCHIVE_BACKEND_MEMBER"] in members:
+        raise SystemExit("backend can still invoke the worker during cutover")
+    if os.environ["LETTER_ARCHIVE_WORKER_MEMBER"] in members:
+        raise SystemExit("worker can still hand off during cutover")
+'
+
+gcloud run jobs replace rendered/cloudrun/backend-backfill-dimensions-job.yaml \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --quiet
+gcloud run jobs replace rendered/cloudrun/backend-worker-job.yaml \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --region="$LETTER_ARCHIVE_REGION" \
+  --quiet
+
+export LETTER_ARCHIVE_SERVICE=letter-archive-backend
+export LETTER_ARCHIVE_SERVICE_ACCOUNT="$LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT"
+export LETTER_ARCHIVE_IMAGE_REPOSITORY="$LETTER_ARCHIVE_BACKEND_IMAGE_REPOSITORY"
+export LETTER_ARCHIVE_PRODUCTION_URL="$LETTER_ARCHIVE_BACKEND_PRODUCTION_URL"
+export LETTER_ARCHIVE_SERVICE_MANIFEST=rendered/cloudrun/backend-service.yaml
+export LETTER_ARCHIVE_WORKER_JOB_NAME="$worker_job"
+bash deploy/cloudrun/promote-service.sh
+
+# The backend and worker are now one committed release unit. Do not restore the
+# old jobs if a later frontend-only promotion fails.
+backend_committed=true
+resume_scheduler
+rollback_jobs=false
+
+export LETTER_ARCHIVE_SERVICE=letter-archive-frontend
+export LETTER_ARCHIVE_SERVICE_ACCOUNT="$LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT"
+export LETTER_ARCHIVE_IMAGE_REPOSITORY="$LETTER_ARCHIVE_FRONTEND_IMAGE_REPOSITORY"
+export LETTER_ARCHIVE_PRODUCTION_URL="$LETTER_ARCHIVE_FRONTEND_PRODUCTION_URL"
+export LETTER_ARCHIVE_SERVICE_MANIFEST=rendered/cloudrun/frontend-service.yaml
+unset LETTER_ARCHIVE_WORKER_JOB_NAME
+bash deploy/cloudrun/promote-service.sh
+
+trap - EXIT
+echo "Full production release completed"

--- a/deploy/cloudrun/release-release-lock.sh
+++ b/deploy/cloudrun/release-release-lock.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${LETTER_ARCHIVE_PROJECT_ID:?Missing LETTER_ARCHIVE_PROJECT_ID}"
+: "${LETTER_ARCHIVE_BUILD_ID:?Missing LETTER_ARCHIVE_BUILD_ID}"
+: "${LETTER_ARCHIVE_RELEASE_SHA:?Missing LETTER_ARCHIVE_RELEASE_SHA}"
+: "${LETTER_ARCHIVE_RELEASE_LOCK_BUCKET:?Missing LETTER_ARCHIVE_RELEASE_LOCK_BUCKET}"
+
+lock_uri="gs://${LETTER_ARCHIVE_RELEASE_LOCK_BUCKET}/production.lock"
+expected_payload="${LETTER_ARCHIVE_BUILD_ID} ${LETTER_ARCHIVE_RELEASE_SHA}"
+current_payload="$(
+  gcloud storage cat "$lock_uri" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID"
+)"
+if [[ "$current_payload" != "$expected_payload" ]]; then
+  echo "Refusing to release a production lock owned by another build" >&2
+  exit 1
+fi
+
+lock_generation="$(
+  gcloud storage objects describe "$lock_uri" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --format='value(generation)'
+)"
+if [[ ! "$lock_generation" =~ ^[0-9]+$ ]]; then
+  echo "Production release lock generation is invalid" >&2
+  exit 1
+fi
+
+gcloud storage rm "$lock_uri" \
+  --project="$LETTER_ARCHIVE_PROJECT_ID" \
+  --if-generation-match="$lock_generation"
+echo "Released production lock for build $LETTER_ARCHIVE_BUILD_ID"

--- a/deploy/cloudrun/render-manifests.sh
+++ b/deploy/cloudrun/render-manifests.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+template_directory="${1:-deploy/cloudrun}"
+output_directory="${2:-rendered/cloudrun}"
+shift "$(( $# >= 2 ? 2 : $# ))"
+
+if [[ ! -d "$template_directory" ]]; then
+  echo "Cloud Run manifest template directory does not exist: $template_directory" >&2
+  exit 1
+fi
+if [[ "$template_directory" == "$output_directory" ]]; then
+  echo "Cloud Run manifests must render to a separate output directory" >&2
+  exit 1
+fi
+if [[ -e "$output_directory" ]]; then
+  echo "Cloud Run manifest output already exists: $output_directory" >&2
+  exit 1
+fi
+
+validate_render_value() {
+  local variable_name="$1"
+  local expected_pattern="$2"
+  local variable_value="${!variable_name:-}"
+
+  if [[ -z "$variable_value" ]]; then
+    echo "Missing required manifest render value: $variable_name" >&2
+    exit 1
+  fi
+  if [[ ! "$variable_value" =~ $expected_pattern ]]; then
+    echo "Invalid manifest render value: $variable_name" >&2
+    exit 1
+  fi
+}
+
+shopt -s nullglob
+if [[ "$#" -gt 0 ]]; then
+  template_files=()
+  for template_name in "$@"; do
+    if [[ ! "$template_name" =~ ^[a-z0-9-]+\.yaml$ ]]; then
+      echo "Invalid Cloud Run manifest template name: $template_name" >&2
+      exit 1
+    fi
+    template_file="$template_directory/$template_name"
+    if [[ ! -f "$template_file" ]]; then
+      echo "Cloud Run manifest template does not exist: $template_file" >&2
+      exit 1
+    fi
+    template_files+=("$template_file")
+  done
+else
+  template_files=("$template_directory"/*.yaml)
+fi
+if [[ "${#template_files[@]}" -eq 0 ]]; then
+  echo "No Cloud Run YAML manifest templates found in: $template_directory" >&2
+  exit 1
+fi
+
+templates_require() {
+  local placeholder="$1"
+  grep -q "$placeholder" "${template_files[@]}"
+}
+
+project_id_pattern='^[a-z][a-z0-9-]{4,28}[a-z0-9]$'
+service_account_pattern="^[a-z][a-z0-9-]{4,28}[a-z0-9]@${project_id_pattern:1:-1}\\.iam\\.gserviceaccount\\.com$"
+image_pattern='^[a-z0-9.-]+-docker\.pkg\.dev/[a-z][a-z0-9-]{4,28}[a-z0-9]/[a-z0-9._-]+/[a-z0-9._/-]+(:[A-Za-z0-9._-]+|@sha256:[0-9a-f]{64})$'
+
+if templates_require '__PROJECT_ID__'; then
+  validate_render_value LETTER_ARCHIVE_PROJECT_ID "$project_id_pattern"
+fi
+if templates_require '__REGION__'; then
+  validate_render_value LETTER_ARCHIVE_REGION '^[a-z]+-[a-z0-9]+[0-9]$'
+fi
+if templates_require '__CLOUD_SQL_INSTANCE__'; then
+  validate_render_value LETTER_ARCHIVE_CLOUD_SQL_INSTANCE \
+    '^[a-z][a-z0-9-]{0,96}[a-z0-9]$'
+fi
+if templates_require '__ARCHIVE_BUCKET__'; then
+  validate_render_value LETTER_ARCHIVE_ARCHIVE_BUCKET \
+    '^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$'
+fi
+if templates_require '__DOMAIN__'; then
+  validate_render_value LETTER_ARCHIVE_DOMAIN \
+    '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$'
+fi
+if templates_require '__BACKEND_SERVICE_ACCOUNT__'; then
+  validate_render_value LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT \
+    "$service_account_pattern"
+fi
+if templates_require '__FRONTEND_SERVICE_ACCOUNT__'; then
+  validate_render_value LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT \
+    "$service_account_pattern"
+fi
+if templates_require '__WORKER_SERVICE_ACCOUNT__'; then
+  validate_render_value LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT \
+    "$service_account_pattern"
+fi
+if templates_require '__MIGRATE_SERVICE_ACCOUNT__'; then
+  validate_render_value LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT \
+    "$service_account_pattern"
+fi
+if templates_require '__BACKFILL_SERVICE_ACCOUNT__'; then
+  validate_render_value LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT \
+    "$service_account_pattern"
+fi
+if templates_require '__MIGRATION_RELEASE_MODE__'; then
+  validate_render_value LETTER_ARCHIVE_MIGRATION_RELEASE_MODE \
+    '^(automatic|maintenance)$'
+fi
+if templates_require '__RELEASE_SHA__'; then
+  validate_render_value LETTER_ARCHIVE_RELEASE_SHA '^[0-9a-f]{40}$'
+fi
+if templates_require '__BACKEND_IMAGE__'; then
+  validate_render_value LETTER_ARCHIVE_BACKEND_IMAGE "$image_pattern"
+fi
+if templates_require '__FRONTEND_IMAGE__'; then
+  validate_render_value LETTER_ARCHIVE_FRONTEND_IMAGE "$image_pattern"
+fi
+
+output_parent="$(dirname "$output_directory")"
+mkdir -p "$output_parent"
+staging_directory="$(mktemp -d "$output_parent/.cloudrun-render.XXXXXX")"
+
+cleanup_staging_directory() {
+  local staged_files=("$staging_directory"/*)
+  for staged_file in "${staged_files[@]}"; do
+    rm -f -- "$staged_file"
+  done
+  rmdir -- "$staging_directory" 2>/dev/null || true
+}
+trap cleanup_staging_directory EXIT
+
+for template_file in "${template_files[@]}"; do
+  rendered_file="$staging_directory/$(basename "$template_file")"
+  sed \
+    -e "s|__PROJECT_ID__|${LETTER_ARCHIVE_PROJECT_ID:-}|g" \
+    -e "s|__REGION__|${LETTER_ARCHIVE_REGION:-}|g" \
+    -e "s|__CLOUD_SQL_INSTANCE__|${LETTER_ARCHIVE_CLOUD_SQL_INSTANCE:-}|g" \
+    -e "s|__ARCHIVE_BUCKET__|${LETTER_ARCHIVE_ARCHIVE_BUCKET:-}|g" \
+    -e "s|__DOMAIN__|${LETTER_ARCHIVE_DOMAIN:-}|g" \
+    -e "s|__BACKEND_SERVICE_ACCOUNT__|${LETTER_ARCHIVE_BACKEND_SERVICE_ACCOUNT:-}|g" \
+    -e "s|__FRONTEND_SERVICE_ACCOUNT__|${LETTER_ARCHIVE_FRONTEND_SERVICE_ACCOUNT:-}|g" \
+    -e "s|__WORKER_SERVICE_ACCOUNT__|${LETTER_ARCHIVE_WORKER_SERVICE_ACCOUNT:-}|g" \
+    -e "s|__MIGRATE_SERVICE_ACCOUNT__|${LETTER_ARCHIVE_MIGRATE_SERVICE_ACCOUNT:-}|g" \
+    -e "s|__BACKFILL_SERVICE_ACCOUNT__|${LETTER_ARCHIVE_BACKFILL_SERVICE_ACCOUNT:-}|g" \
+    -e "s|__MIGRATION_RELEASE_MODE__|${LETTER_ARCHIVE_MIGRATION_RELEASE_MODE:-}|g" \
+    -e "s|__RELEASE_SHA__|${LETTER_ARCHIVE_RELEASE_SHA:-}|g" \
+    -e "s|__BACKEND_IMAGE__|${LETTER_ARCHIVE_BACKEND_IMAGE:-}|g" \
+    -e "s|__FRONTEND_IMAGE__|${LETTER_ARCHIVE_FRONTEND_IMAGE:-}|g" \
+    "$template_file" > "$rendered_file"
+done
+
+rendered_files=("$staging_directory"/*.yaml)
+unresolved_placeholder_pattern='__[A-Z][A-Z0-9_]*__|(^|[^A-Z0-9_])(PROJECT_NUMBER|PROJECT_ID|REGION|CLOUD_SQL_INSTANCE|ARCHIVE_BUCKET|YOUR_DOMAIN|SERVICE_ACCOUNT_EMAIL|BACKEND_IMAGE|FRONTEND_IMAGE)([^A-Z0-9_]|$)'
+
+if grep -nE "$unresolved_placeholder_pattern" "${rendered_files[@]}"; then
+  echo "Unresolved Cloud Run manifest placeholders remain after rendering" >&2
+  exit 1
+fi
+
+mv "$staging_directory" "$output_directory"
+trap - EXIT

--- a/deploy/cloudrun/select-release-scope.sh
+++ b/deploy/cloudrun/select-release-scope.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+backend_revision="${1:-}"
+frontend_revision="${2:-}"
+head_revision="${3:-}"
+
+sha_pattern='^[0-9a-f]{40}$'
+if [[ ! "$head_revision" =~ $sha_pattern ]]; then
+  echo "full"
+  exit 0
+fi
+if ! git cat-file -e "${head_revision}^{commit}" 2>/dev/null; then
+  echo "full"
+  exit 0
+fi
+
+# GitHub concurrency prevents overlap while both controller jobs are alive, but
+# it does not guarantee commit order. An older workflow must never roll back a
+# newer release that reached either service first.
+for deployed_revision in "$backend_revision" "$frontend_revision"; do
+  if [[ ! "$deployed_revision" =~ $sha_pattern ]]; then
+    continue
+  fi
+  if ! git cat-file -e "${deployed_revision}^{commit}" 2>/dev/null; then
+    continue
+  fi
+  if [[ "$deployed_revision" != "$head_revision" ]] \
+    && git merge-base --is-ancestor "$head_revision" "$deployed_revision"; then
+    echo "stale"
+    exit 0
+  fi
+done
+
+if [[ ! "$backend_revision" =~ $sha_pattern ]]; then
+  echo "full"
+  exit 0
+fi
+if ! git cat-file -e "${backend_revision}^{commit}" 2>/dev/null; then
+  echo "full"
+  exit 0
+fi
+
+while IFS= read -r changed_file; do
+  case "$changed_file" in
+    backend/*|deploy/*|cloudbuild.release.yaml|cloudbuild.deploy.yaml|.github/workflows/ci.yml)
+      echo "full"
+      exit 0
+      ;;
+  esac
+done < <(git diff --name-only "$backend_revision" "$head_revision")
+
+if [[ ! "$frontend_revision" =~ $sha_pattern ]]; then
+  echo "full"
+  exit 0
+fi
+if ! git cat-file -e "${frontend_revision}^{commit}" 2>/dev/null; then
+  echo "full"
+  exit 0
+fi
+if [[ "$backend_revision" == "$head_revision" \
+  && "$frontend_revision" != "$head_revision" ]] \
+  && git merge-base --is-ancestor "$frontend_revision" "$head_revision"; then
+  echo "frontend"
+  exit 0
+fi
+
+while IFS= read -r changed_file; do
+  case "$changed_file" in
+    frontend/*|cloudbuild.frontend-release.yaml)
+      echo "frontend"
+      exit 0
+      ;;
+  esac
+done < <(git diff --name-only "$frontend_revision" "$head_revision")
+
+echo "none"

--- a/deploy/cloudrun/verify-build-source.sh
+++ b/deploy/cloudrun/verify-build-source.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_BUILD_LOCATION
+  LETTER_ARCHIVE_BUILD_ID
+  LETTER_ARCHIVE_RELEASE_SHA
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing build source verification value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$LETTER_ARCHIVE_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release SHA must be a full lowercase Git commit SHA" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_PROJECT_ID" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+  echo "Build project ID is invalid" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_BUILD_LOCATION" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]]; then
+  echo "Build location is invalid" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_BUILD_ID" =~ ^[0-9a-f-]{8,64}$ ]]; then
+  echo "Build ID contains unexpected characters" >&2
+  exit 1
+fi
+
+resolved_revision="$(
+  gcloud builds describe "$LETTER_ARCHIVE_BUILD_ID" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_BUILD_LOCATION" \
+    --format='value(sourceProvenance.resolvedGitSource.revision)'
+)"
+
+if [[ "$resolved_revision" != "$LETTER_ARCHIVE_RELEASE_SHA" ]]; then
+  echo "Build source revision does not match the requested release SHA" >&2
+  echo "Expected: $LETTER_ARCHIVE_RELEASE_SHA" >&2
+  echo "Resolved: ${resolved_revision:-missing}" >&2
+  exit 1
+fi
+
+echo "Verified build source revision $resolved_revision"

--- a/deploy/cloudrun/verify-current-main.sh
+++ b/deploy/cloudrun/verify-current-main.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${LETTER_ARCHIVE_RELEASE_SHA:?Missing LETTER_ARCHIVE_RELEASE_SHA}"
+
+if [[ ! "$LETTER_ARCHIVE_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release SHA must be a full lowercase Git commit SHA" >&2
+  exit 1
+fi
+
+current_main="$(
+  git ls-remote \
+    https://github.com/MLGalusha/letter-archive.git \
+    refs/heads/main \
+    | awk 'NR == 1 { print $1 }'
+)"
+if [[ ! "$current_main" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Could not resolve the current remote main commit" >&2
+  exit 1
+fi
+if [[ "$current_main" != "$LETTER_ARCHIVE_RELEASE_SHA" ]]; then
+  echo "Refusing stale release: main is now $current_main" >&2
+  exit 1
+fi
+
+echo "Release commit is still current on main"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,164 @@
+# Production Deployment
+
+## Release authority
+
+GitHub Actions is the only automatic production release authority. Required CI
+must pass on protected `main` before the `Production Release` job authenticates
+to Google Cloud with short-lived Workload Identity Federation credentials.
+GitHub stores no Google service-account key.
+
+The release job submits the exact remote commit to a regional Cloud Build and
+passes the same full SHA as `_TAG`. The build verifies that Cloud Build's
+resolved source provenance equals that SHA before it builds or pushes an image.
+After acquiring the GCP-side release lock, the build also verifies that the SHA
+is still the current remote `main`. A newer deployment is never allowed to be
+rolled back by an older queued build.
+
+The repository variable `AUTOMATIC_RELEASES_ENABLED` is the production kill
+switch:
+
+- `false` — CI still runs, but merges do not start a release.
+- `true` — successful pushes to protected `main` start a release.
+
+The variable must remain `false` until the one-time maintenance baseline through
+migration `0056_repair_extra_content_job_ownership` is complete.
+
+## Release selection
+
+`deploy/cloudrun/select-release-scope.sh` compares the exact release SHA exposed by
+each live service with the new `main` commit, then selects one serialized release:
+
+- `frontend` for frontend-only changes;
+- `full` for backend, deploy, release-workflow, or full-release-config changes;
+- `none` for changes that do not affect a production artifact.
+
+If either service does not expose a valid reachable commit, selection fails safe to a
+full release. This also means a later merge cannot skip backend work left behind by a
+failed earlier release merely because the later commit changed only the frontend.
+
+Frontend-only releases use `cloudbuild.frontend-release.yaml`. They never replace
+a backend job, connect to the database, or run a migration.
+
+Full releases use `cloudbuild.release.yaml`. They build both immutable images,
+run the migration gate and migration job, update the worker and backfill jobs,
+then release backend followed by frontend.
+
+All production builds also acquire
+`gs://letter-archive-485110-release-lock/production.lock`. Object-generation
+preconditions make lock creation, stale-owner cleanup, and release atomic. A
+later build may reap the lock only after Cloud Build reports its owner in a
+terminal state; an active or unverifiable owner fails closed. The build identity
+therefore needs object create, read, and delete access on this bucket only.
+
+## Candidate promotion and rollback
+
+Images are tagged with the full Git SHA for traceability, resolved to an Artifact
+Registry digest, and deployed by digest. `latest` exists only as a Docker layer
+cache and is never a deployment reference.
+
+Each service release:
+
+1. records the one revision receiving 100% of current traffic;
+2. deploys a uniquely tagged candidate revision with zero traffic;
+3. verifies the candidate URL and exact release SHA;
+4. verifies backend database readiness and public auth status, or the frontend
+   admin shell;
+5. promotes the candidate to 100%;
+6. repeats the probes through the production domain;
+7. removes the temporary tag and pins traffic to the exact revision.
+
+A failed candidate receives no production traffic. A failed post-promotion smoke
+test restores the previously serving revision. Automatic rollback is valid only
+because the migration gate permits rolling-compatible migrations.
+
+Before backend promotion, the full release snapshots the worker and backfill job
+definitions, worker invocation IAM, and Scheduler state. A failure restores and
+verifies those snapshots. Once the backend candidate has committed successfully,
+the pipeline does not roll jobs back to an incompatible older version; a later
+Scheduler failure is reported as a distinct critical recovery condition.
+
+## Migration release policy
+
+`backend/src/db/migration-release-policy.ts` defines the production baseline and
+classifies every later migration:
+
+- `automatic` — expand-only and safe while the previous application revision
+  remains available for rollback;
+- `maintenance` — requires a controlled write-quiesced deployment.
+
+CI fails when a post-baseline migration is unclassified. The migration executable
+also verifies that the live Drizzle ledger is the exact ordered prefix of the
+repository journal, including every migration timestamp and SHA-256 SQL hash.
+An automatic release fails before running SQL when the ledger diverges,
+production is behind the baseline, or any pending migration is unclassified or
+maintenance-only.
+
+## Identities
+
+Runtime identities are separate:
+
+- `letter-archive-frontend` — no database, secret, bucket, or worker access;
+- `letter-archive-backend` — API-specific database, secret, bucket, and worker
+  invocation access;
+- `letter-archive-worker` — worker-specific database, OpenAI secret, and bucket
+  access;
+- `letter-archive-migrate` — database migration access only;
+- `letter-archive-backfill` — database and read-only archive access;
+- `letter-archive-build` — Artifact Registry writer and Cloud Run deployer that
+  may act as only the Letter Archive runtime identities;
+- `letter-archive-github` — may submit Cloud Builds and act as the dedicated
+  build identity.
+
+Database credentials are split on the same boundary:
+
+- `database-url-api` and `database-url-worker` use separate DML-only roles;
+- `database-url-migrate` owns migration-managed objects and may create schema
+  objects; and
+- `database-url-backfill` may only read and update `letter_pages`.
+
+The shared legacy `database-url` secret is not granted to these runtime
+identities.
+
+The GitHub Workload Identity provider admits only the numeric Letter Archive
+repository and owner IDs, `refs/heads/main`, and this repository's
+`.github/workflows/ci.yml` workflow reference.
+
+## One-time maintenance baseline
+
+`cloudbuild.deploy.yaml` is the one-time maintenance pipeline. It requires an
+explicit maintenance authorization, but it also establishes and verifies the
+maintenance state itself:
+
+1. build and push the exact reviewed release first;
+2. remove the public backend invoker binding;
+3. route backend traffic to a static maintenance revision with no database,
+   secret, archive, or worker access;
+4. pause scheduled reconciliation when present;
+5. revoke both API-to-worker and worker self-handoff invocation;
+6. remove the legacy worker pool and wait longer than the old API request
+   timeout;
+7. require two consecutive observations with no active worker execution;
+8. run migrations in `maintenance` mode;
+9. deploy the new jobs and backend identities;
+10. privately verify backend release identity, DB readiness, and auth status;
+11. reopen the public backend and promote the frontend candidate.
+
+If the pipeline fails after maintenance begins, the backend remains closed
+instead of reopening an unverified or mixed-version release.
+
+## External controls
+
+- The legacy `deploy-full` and `deploy-frontend` Cloud Build triggers are
+  build-only until the baseline release is proven, then retired.
+- `main` requires the GitHub quality, mocked E2E, and real-server smoke checks.
+- Production releases use GitHub concurrency
+  `letter-archive-production` with cancellation disabled, so releases queue
+  rather than race. The GCS generation-checked lock preserves serialization if
+  a GitHub runner disappears after submitting Cloud Build.
+- The one-time bootstrap may temporarily require project-level Cloud Run
+  administration to create missing Letter Archive jobs. Immediately after that
+  bootstrap, grant the build identity administration only on the exact Letter
+  Archive services/jobs and remove its project-level Cloud Run administrator
+  role.
+- SpecFinder has separate services and identities and is not a release target or
+  permission member in this workflow.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -14,17 +14,28 @@ schema.ts + reviewed SQL + journal entry → validation → drizzle:migrate
 5. Run `npm run drizzle:migrate` to apply it locally
 
 `npm run drizzle:generate` is intentionally guarded and exits without writing files.
-The SQL journal and `schema.ts` are current through migration 0055, while Drizzle's
+The SQL journal and `schema.ts` are current through migration 0056, while Drizzle's
 snapshot lineage stops at 0013. In that state `drizzle-kit generate` compares the
 current schema with a stale snapshot and can propose DDL for changes that migrations
-0014–0055 already made.
+0014–0056 already made.
 
 Until a dedicated snapshot-baseline repair is completed, every migration must:
 
 - be registered explicitly in `meta/_journal.json`;
 - stay consistent with `schema.ts`;
 - include filesystem validation and a fresh PostgreSQL regression;
-- document mixed-version behavior and the later contraction step.
+- document mixed-version behavior and the later contraction step;
+- add an explicit `automatic` or `maintenance` classification to
+  `src/db/migration-release-policy.ts` for every migration after the production
+  automatic-release baseline.
+
+An `automatic` migration must be expand-only and safe while the previous
+application revision is still serving or being restored. Destructive DDL,
+contract migrations, and changes that reject old writers are `maintenance`.
+The production migration executable checks both this policy and the live applied
+migration ledger before running SQL. The live ledger must be the exact ordered
+prefix of the repository journal, including each timestamp and SHA-256 SQL hash;
+a matching count alone is not sufficient.
 
 Do not invoke `npx drizzle-kit generate` directly as a workaround. Re-enabling
 generation requires reconstructing a current snapshot in an isolated copy, proving it

--- a/e2e/tests/letter-review.mocked.spec.ts
+++ b/e2e/tests/letter-review.mocked.spec.ts
@@ -518,26 +518,34 @@ test.describe('@mocked Letter Review', () => {
     const mockedApi = await openMockLetterReview(page, initialLetter);
     let markRequestStarted!: () => void;
     let releaseResponse!: () => void;
+    let markResponseSettled!: () => void;
     const requestStarted = new Promise<void>((resolve) => {
       markRequestStarted = resolve;
     });
     const responseGate = new Promise<void>((resolve) => {
       releaseResponse = resolve;
     });
+    const responseSettled = new Promise<void>((resolve) => {
+      markResponseSettled = resolve;
+    });
     await page.route(/\/transcribe-letter$/, async (route) => {
       markRequestStarted();
       await responseGate;
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          letter: initialLetter,
-          transcribed: {
-            pageCount: initialLetter.transcript.pages.length,
-            textLength: initialLetter.transcript.fullText.length,
-          },
-        }),
-      });
+      try {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            letter: initialLetter,
+            transcribed: {
+              pageCount: initialLetter.transcript.pages.length,
+              textLength: initialLetter.transcript.fullText.length,
+            },
+          }),
+        });
+      } finally {
+        markResponseSettled();
+      }
     });
 
     await transcriptionSection(page).locator('.transcribe-btn').click();
@@ -552,12 +560,11 @@ test.describe('@mocked Letter Review', () => {
     }).click();
     await expect(page).toHaveURL(/\/admin$/);
     await expect(page.locator('.letter-review-page')).toHaveCount(0);
-    const response = page.waitForResponse(/\/transcribe-letter$/);
     releaseResponse();
-    await response;
-    await page.evaluate(() => new Promise<void>((resolve) => {
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-    }));
+    await responseSettled;
+    // Let the abandoned mutation continuation run without borrowing a page
+    // execution context; the SPA may still replace its route context here.
+    await page.waitForTimeout(100);
 
     expect(mockedApi.transcribeExtrasRequests).toHaveLength(0);
     await expect(page.locator('.toast', {

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -115,18 +115,14 @@ test.describe('Navigation', () => {
         .then(() => true).catch(() => false);
       test.skip(!hasRow, 'No letters in database');
 
-      await firstRow.click();
+      // Click a non-interactive cell. The row center can land on the review
+      // flag button, which intentionally stops propagation.
+      await firstRow.locator('[data-column="sender"]').click();
       await page.waitForURL(/\/admin\/letters\//);
 
-      // Navigate back
-      const backLink = page.locator('a[href="/admin"], button:has-text("Back"), .back-link');
-
-      if (await backLink.first().isVisible()) {
-        await backLink.first().click();
-      } else {
-        await page.goBack();
-      }
-
+      // Browser history remains available even if the selected letter opens a
+      // full-screen review surface that intentionally blocks sidebar clicks.
+      await page.goBack();
       await page.waitForURL(/\/admin$/);
       expect(page.url()).toMatch(/\/admin$/);
     });
@@ -217,7 +213,7 @@ test.describe('Navigation', () => {
         .then(() => true).catch(() => false);
       test.skip(!hasRow, 'No letters in database');
 
-      await firstRow.click();
+      await firstRow.locator('[data-column="sender"]').click();
       await page.waitForURL(/\/admin\/letters\//);
 
       const url = page.url();

--- a/e2e/tests/utils/test-helpers.ts
+++ b/e2e/tests/utils/test-helpers.ts
@@ -17,6 +17,40 @@ export async function installMockImageSessionApi(page: Page): Promise<void> {
   await page.route(`${API_BASE_URL}/auth/image-session`, async (route) => {
     await route.fulfill({ status: 204 });
   });
+
+  // The authenticated admin shell always mounts the notification badge and
+  // stream. Keep those shell-owned requests inside the mocked boundary too:
+  // an unmocked 401 intentionally clears adminToken and redirects to login.
+  await page.route(`${API_BASE_URL}/admin/notifications/unread-count`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: 0,
+        bySeverity: { info: 0, warn: 0, error: 0, critical: 0 },
+        maxSeverity: null,
+      }),
+    });
+  });
+  await page.route(`${API_BASE_URL}/admin/notifications/stream-token`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        token: 'mock-notification-stream-token',
+        expiresAt: Date.now() + 60_000,
+      }),
+    });
+  });
+  await page.route(
+    `${API_BASE_URL}/admin/notifications/stream?token=mock-notification-stream-token`,
+    async (route) => {
+      await route.fulfill({
+        status: 204,
+        contentType: 'text/event-stream',
+      });
+    },
+  );
 }
 
 export async function waitForAdminDashboardReady(page: Page): Promise<void> {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,8 +13,10 @@ ARG VITE_API_URL
 ENV VITE_API_URL=${VITE_API_URL}
 ARG VITE_SITE_URL
 ENV VITE_SITE_URL=${VITE_SITE_URL}
+ARG RELEASE_SHA=development
 
 RUN npm run build
+RUN printf '{"releaseSha":"%s"}\n' "${RELEASE_SHA}" > dist/version.json
 
 # ---- Stage 2: Serve with nginx ----
 FROM nginx:alpine AS production


### PR DESCRIPTION
## Summary
- add protected-main GitHub Actions release orchestration with exact-SHA Cloud Build submissions
- add migration-ledger safety gates, release locking, maintenance quiescence, health/version identity, and rollback-safe service promotion
- split production runtime database identities and secret references by API, worker, migration, and backfill responsibility
- harden deployment manifest rendering and add failure-path regression tests
- fix mocked and smoke E2E assumptions exposed by the redesigned admin UI

## Validation
- backend: 116 files / 1206 tests
- frontend: 155 files / 1098 tests
- mocked E2E: 79/79
- real-server smoke E2E: 38 passed, 1 skipped
- focused deployment suite: 59/59
- backend typecheck and frontend build
- backend/frontend production Docker builds
- disposable database migration suite
- shell syntax, YAML parsing, manifest dry-run, and diff checks
- independent backend-integrity and security reviews: clean

Automatic releases remain disabled until this PR is merged, the controlled bootstrap deployment succeeds, and resource-scoped GCP IAM is verified. SpecFinder is out of scope and untouched.