### PR TITLE
Preflight bootstrap migration access

### DIFF
--- a/backend/src/cli/migrate.ts
+++ b/backend/src/cli/migrate.ts
@@ -95,22 +95,123 @@ async function migrationJournal(): Promise<MigrationJournalEntry[]> {
 async function assertMigrationDatabasePrivileges(): Promise<void> {
   const [privileges] = await sql<{
     canCreateSchema: boolean;
+    canCreateInDrizzle: boolean;
+    canCreateInPublic: boolean;
+    canWriteLedger: boolean;
   }[]>`
-    SELECT has_database_privilege(
-      current_user,
-      current_database(),
-      'CREATE'
-    ) AS "canCreateSchema"
+    SELECT
+      has_database_privilege(
+        current_user,
+        current_database(),
+        'CREATE'
+      ) AS "canCreateSchema",
+      CASE
+        WHEN to_regnamespace('drizzle') IS NULL THEN true
+        ELSE has_schema_privilege(
+          current_user,
+          'drizzle',
+          'USAGE, CREATE'
+        )
+      END AS "canCreateInDrizzle",
+      has_schema_privilege(
+        current_user,
+        'public',
+        'USAGE, CREATE'
+      ) AS "canCreateInPublic",
+      CASE
+        WHEN to_regclass('drizzle.__drizzle_migrations') IS NULL THEN true
+        ELSE has_table_privilege(
+          current_user,
+          'drizzle.__drizzle_migrations',
+          'SELECT, INSERT'
+        )
+      END AS "canWriteLedger"
   `;
-  if (!privileges?.canCreateSchema) {
+  const missingPrivileges = [
+    !privileges?.canCreateSchema && 'CREATE on the current database',
+    !privileges?.canCreateInDrizzle && 'USAGE/CREATE on schema drizzle',
+    !privileges?.canCreateInPublic && 'USAGE/CREATE on schema public',
+    !privileges?.canWriteLedger
+      && 'SELECT/INSERT on drizzle.__drizzle_migrations',
+  ].filter((value): value is string => Boolean(value));
+  if (missingPrivileges.length > 0) {
     throw new Error(
-      'Migration database role requires CREATE on the current database',
+      'Migration database role is missing: '
+      + missingPrivileges.join(', '),
+    );
+  }
+
+  const unownedObjects = await sql<{
+    objectIdentity: string;
+  }[]>`
+    WITH migration_objects AS (
+      SELECT
+        'relation ' || format('%I.%I', namespace.nspname, class.relname)
+          AS object_identity,
+        class.relowner AS owner_oid
+      FROM pg_class AS class
+      JOIN pg_namespace AS namespace
+        ON namespace.oid = class.relnamespace
+      WHERE namespace.nspname IN ('public', 'drizzle')
+        AND class.relkind IN ('r', 'p', 'S', 'v', 'm', 'f')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_depend AS dependency
+          WHERE dependency.classid = 'pg_class'::regclass
+            AND dependency.objid = class.oid
+            AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+
+      SELECT
+        'type ' || format('%I.%I', namespace.nspname, type.typname),
+        type.typowner
+      FROM pg_type AS type
+      JOIN pg_namespace AS namespace
+        ON namespace.oid = type.typnamespace
+      WHERE namespace.nspname IN ('public', 'drizzle')
+        AND type.typtype IN ('d', 'e')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_depend AS dependency
+          WHERE dependency.classid = 'pg_type'::regclass
+            AND dependency.objid = type.oid
+            AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+
+      SELECT
+        'function ' || procedure.oid::regprocedure::text,
+        procedure.proowner
+      FROM pg_proc AS procedure
+      JOIN pg_namespace AS namespace
+        ON namespace.oid = procedure.pronamespace
+      WHERE namespace.nspname IN ('public', 'drizzle')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_depend AS dependency
+          WHERE dependency.classid = 'pg_proc'::regclass
+            AND dependency.objid = procedure.oid
+            AND dependency.deptype = 'e'
+        )
+    )
+    SELECT object_identity AS "objectIdentity"
+    FROM migration_objects
+    WHERE NOT pg_has_role(current_user, owner_oid, 'USAGE')
+    ORDER BY object_identity
+  `;
+  if (unownedObjects.length > 0) {
+    throw new Error(
+      'Migration database role does not own migration-managed objects: '
+      + unownedObjects.map(({ objectIdentity }) => objectIdentity).join(', '),
     );
   }
 
   // Drizzle performs this statement before reading or applying its ledger.
-  // Running the same harmless, idempotent statement during preflight catches
-  // database-level privilege drift before production enters maintenance.
+  // The explicit privilege and ownership checks above also prove its ledger
+  // insert and pending ALTER/CREATE authority without mutating application data.
   await sql`CREATE SCHEMA IF NOT EXISTS drizzle`;
 }
 

--- a/backend/src/cli/migrate.ts
+++ b/backend/src/cli/migrate.ts
@@ -15,6 +15,19 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(__dirname, '../../src/db/migrations');
 
+function isPreflightOnly(): boolean {
+  const argumentsAfterScript = process.argv.slice(2);
+  const unexpected = argumentsAfterScript.filter(
+    (argument) => argument !== '--preflight',
+  );
+  if (unexpected.length > 0) {
+    throw new Error(
+      `Unsupported migration argument(s): ${unexpected.join(', ')}`,
+    );
+  }
+  return argumentsAfterScript.includes('--preflight');
+}
+
 async function appliedMigrationLedger(): Promise<AppliedMigrationEntry[]> {
   try {
     const rows = await sql<{
@@ -79,7 +92,30 @@ async function migrationJournal(): Promise<MigrationJournalEntry[]> {
   }));
 }
 
+async function assertMigrationDatabasePrivileges(): Promise<void> {
+  const [privileges] = await sql<{
+    canCreateSchema: boolean;
+  }[]>`
+    SELECT has_database_privilege(
+      current_user,
+      current_database(),
+      'CREATE'
+    ) AS "canCreateSchema"
+  `;
+  if (!privileges?.canCreateSchema) {
+    throw new Error(
+      'Migration database role requires CREATE on the current database',
+    );
+  }
+
+  // Drizzle performs this statement before reading or applying its ledger.
+  // Running the same harmless, idempotent statement during preflight catches
+  // database-level privilege drift before production enters maintenance.
+  await sql`CREATE SCHEMA IF NOT EXISTS drizzle`;
+}
+
 async function main(): Promise<void> {
+  const preflightOnly = isPreflightOnly();
   const mode = process.env.MIGRATION_RELEASE_MODE;
   if (mode !== 'automatic' && mode !== 'maintenance') {
     throw new Error(
@@ -101,6 +137,11 @@ async function main(): Promise<void> {
     `Migration release policy accepted ${pending.length} pending migration(s) `
     + `in ${mode} mode`,
   );
+  await assertMigrationDatabasePrivileges();
+  if (preflightOnly) {
+    console.log('Migration preflight completed without applying migrations');
+    return;
+  }
   await migrate(db, { migrationsFolder });
   console.log(`Migrations applied from ${migrationsFolder}`);
 }

--- a/backend/src/cli/migrate.ts
+++ b/backend/src/cli/migrate.ts
@@ -97,7 +97,10 @@ async function assertMigrationDatabasePrivileges(): Promise<void> {
     canCreateSchema: boolean;
     canCreateInDrizzle: boolean;
     canCreateInPublic: boolean;
-    canWriteLedger: boolean;
+    canInsertLedger: boolean;
+    canReadLedger: boolean;
+    canUseDrizzle: boolean;
+    canUsePublic: boolean;
   }[]>`
     SELECT
       has_database_privilege(
@@ -110,29 +113,54 @@ async function assertMigrationDatabasePrivileges(): Promise<void> {
         ELSE has_schema_privilege(
           current_user,
           'drizzle',
-          'USAGE, CREATE'
+          'CREATE'
         )
       END AS "canCreateInDrizzle",
       has_schema_privilege(
         current_user,
         'public',
-        'USAGE, CREATE'
+        'CREATE'
       ) AS "canCreateInPublic",
+      CASE
+        WHEN to_regnamespace('drizzle') IS NULL THEN true
+        ELSE has_schema_privilege(
+          current_user,
+          'drizzle',
+          'USAGE'
+        )
+      END AS "canUseDrizzle",
+      has_schema_privilege(
+        current_user,
+        'public',
+        'USAGE'
+      ) AS "canUsePublic",
       CASE
         WHEN to_regclass('drizzle.__drizzle_migrations') IS NULL THEN true
         ELSE has_table_privilege(
           current_user,
           'drizzle.__drizzle_migrations',
-          'SELECT, INSERT'
+          'INSERT'
         )
-      END AS "canWriteLedger"
+      END AS "canInsertLedger",
+      CASE
+        WHEN to_regclass('drizzle.__drizzle_migrations') IS NULL THEN true
+        ELSE has_table_privilege(
+          current_user,
+          'drizzle.__drizzle_migrations',
+          'SELECT'
+        )
+      END AS "canReadLedger"
   `;
   const missingPrivileges = [
     !privileges?.canCreateSchema && 'CREATE on the current database',
-    !privileges?.canCreateInDrizzle && 'USAGE/CREATE on schema drizzle',
-    !privileges?.canCreateInPublic && 'USAGE/CREATE on schema public',
-    !privileges?.canWriteLedger
-      && 'SELECT/INSERT on drizzle.__drizzle_migrations',
+    !privileges?.canUseDrizzle && 'USAGE on schema drizzle',
+    !privileges?.canCreateInDrizzle && 'CREATE on schema drizzle',
+    !privileges?.canUsePublic && 'USAGE on schema public',
+    !privileges?.canCreateInPublic && 'CREATE on schema public',
+    !privileges?.canReadLedger
+      && 'SELECT on drizzle.__drizzle_migrations',
+    !privileges?.canInsertLedger
+      && 'INSERT on drizzle.__drizzle_migrations',
   ].filter((value): value is string => Boolean(value));
   if (missingPrivileges.length > 0) {
     throw new Error(

--- a/backend/src/services/__tests__/deployment-manifest-renderer.test.ts
+++ b/backend/src/services/__tests__/deployment-manifest-renderer.test.ts
@@ -225,6 +225,9 @@ describe('Cloud Run deployment manifest renderer', () => {
     expect(manifests.get('backend-migrate-job.yaml')).toMatch(
       /name: MIGRATION_RELEASE_MODE\s+value: automatic/,
     );
+    expect(manifests.get('backend-migrate-job.yaml')).toMatch(
+      /args:\s+- dist\/cli\/migrate\.js\s+- --preflight/,
+    );
   });
 
   it('fails closed when a required render value is missing', () => {

--- a/backend/src/services/__tests__/processing-ownership.architecture.test.ts
+++ b/backend/src/services/__tests__/processing-ownership.architecture.test.ts
@@ -353,9 +353,10 @@ describe('processing execution ownership', () => {
       path.join(sourceRoot, 'cli/migrate.ts'),
       'utf8',
     );
-    expect(migrationCli).toContain(
-      "'SELECT, INSERT'",
-    );
+    expect(migrationCli).toContain("'SELECT'");
+    expect(migrationCli).toContain("'INSERT'");
+    expect(migrationCli).not.toContain("'SELECT, INSERT'");
+    expect(migrationCli).not.toContain("'USAGE, CREATE'");
     expect(migrationCli).toContain(
       "namespace.nspname IN ('public', 'drizzle')",
     );

--- a/backend/src/services/__tests__/processing-ownership.architecture.test.ts
+++ b/backend/src/services/__tests__/processing-ownership.architecture.test.ts
@@ -342,6 +342,20 @@ describe('processing execution ownership', () => {
     expect(migrationPolicy).toContain(
       "automaticMigrationBaselineTag =\n  '0056_repair_extra_content_job_ownership'",
     );
+
+    const migrationCli = await readFile(
+      path.join(sourceRoot, 'cli/migrate.ts'),
+      'utf8',
+    );
+    expect(migrationCli).toContain(
+      "'SELECT, INSERT'",
+    );
+    expect(migrationCli).toContain(
+      "namespace.nspname IN ('public', 'drizzle')",
+    );
+    expect(migrationCli).toContain(
+      "NOT pg_has_role(current_user, owner_oid, 'USAGE')",
+    );
   });
 
   it('keeps scheduled worker reconciliation authenticated and ordered after invoker grants', async () => {

--- a/backend/src/services/__tests__/processing-ownership.architecture.test.ts
+++ b/backend/src/services/__tests__/processing-ownership.architecture.test.ts
@@ -217,6 +217,9 @@ describe('processing execution ownership', () => {
     expect(controlledDeploy).toMatch(
       /id: establish-write-quiescence[\s\S]*?deploy\/cloudrun\/quiesce-production\.sh/,
     );
+    expect(controlledDeploy).toMatch(
+      /id: preflight-migrations[\s\S]*?--args=dist\/cli\/migrate\.js,--preflight/,
+    );
     expect(controlledDeploy).not.toContain(
       'worker-pools delete letter-archive-worker \\\n          --region=${_REGION} --quiet || true',
     );
@@ -232,8 +235,21 @@ describe('processing execution ownership', () => {
       'id: grant-worker-handoff-job-invoke',
     );
     const backendDeploy = controlledDeploy.indexOf('id: deploy-backend');
+    const migrationPreflight = controlledDeploy.indexOf(
+      'id: preflight-migrations',
+    );
+    const writeQuiescence = controlledDeploy.indexOf(
+      'id: establish-write-quiescence',
+    );
+    const migrationExecution = controlledDeploy.indexOf('id: run-migrations');
 
     expect(workerDeploy).toBeGreaterThan(-1);
+    expect(migrationPreflight).toBeGreaterThan(-1);
+    expect(writeQuiescence).toBeGreaterThan(migrationPreflight);
+    expect(migrationExecution).toBeGreaterThan(writeQuiescence);
+    expect(
+      controlledDeploy.slice(writeQuiescence, migrationExecution),
+    ).toContain('- preflight-migrations');
     expect(backendWorkerGrant).toBeGreaterThan(workerDeploy);
     expect(workerHandoffGrant).toBeGreaterThan(workerDeploy);
     expect(backendDeploy).toBeGreaterThan(backendWorkerGrant);

--- a/backend/src/services/__tests__/processing-ownership.architecture.test.ts
+++ b/backend/src/services/__tests__/processing-ownership.architecture.test.ts
@@ -220,6 +220,9 @@ describe('processing execution ownership', () => {
     expect(controlledDeploy).toMatch(
       /id: preflight-migrations[\s\S]*?--args=dist\/cli\/migrate\.js,--preflight/,
     );
+    expect(controlledDeploy).toMatch(
+      /id: run-migrations[\s\S]*?--args=dist\/cli\/migrate\.js/,
+    );
     expect(controlledDeploy).not.toContain(
       'worker-pools delete letter-archive-worker \\\n          --region=${_REGION} --quiet || true',
     );
@@ -328,6 +331,9 @@ describe('processing execution ownership', () => {
     );
     expect(fullReleaseScript).toContain(
       'gcloud run jobs execute letter-archive-migrate',
+    );
+    expect(fullReleaseScript).toMatch(
+      /gcloud run jobs execute letter-archive-migrate[\s\S]*?--args=dist\/cli\/migrate\.js/,
     );
     expect(fullReleaseScript.indexOf(
       'gcloud run jobs execute letter-archive-migrate',

--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -237,6 +237,7 @@ steps:
       - execute
       - letter-archive-migrate
       - --region=${_REGION}
+      - --args=dist/cli/migrate.js
       - --wait
     waitFor:
       - establish-write-quiescence

--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -181,6 +181,33 @@ steps:
       - deploy/cloudrun/prepare-release-manifests.sh
     waitFor: ['push-backend', 'push-frontend']
 
+  # ── Prove migration access before entering maintenance ──────
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: deploy-migrate-job
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - replace
+      - rendered/cloudrun/backend-migrate-job.yaml
+      - --region=${_REGION}
+    waitFor:
+      - push-backend
+      - prepare-manifests
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: preflight-migrations
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - execute
+      - letter-archive-migrate
+      - --region=${_REGION}
+      - --args=dist/cli/migrate.js,--preflight
+      - --wait
+    waitFor: ['deploy-migrate-job']
+
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: establish-write-quiescence
     entrypoint: bash
@@ -195,23 +222,12 @@ steps:
       - 'LETTER_ARCHIVE_BUILD_ID=${BUILD_ID}'
     args:
       - deploy/cloudrun/quiesce-production.sh
-    waitFor: ['push-backend', 'push-frontend']
-
-  # ── Deploy + run migrations ─────────────────────────────────
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    id: deploy-migrate-job
-    entrypoint: gcloud
-    args:
-      - run
-      - jobs
-      - replace
-      - rendered/cloudrun/backend-migrate-job.yaml
-      - --region=${_REGION}
     waitFor:
       - push-backend
-      - prepare-manifests
-      - establish-write-quiescence
+      - push-frontend
+      - preflight-migrations
 
+  # ── Apply migrations only after writers are quiescent ────────
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: run-migrations
     entrypoint: gcloud
@@ -222,7 +238,9 @@ steps:
       - letter-archive-migrate
       - --region=${_REGION}
       - --wait
-    waitFor: ['deploy-migrate-job']
+    waitFor:
+      - establish-write-quiescence
+      - preflight-migrations
 
   # ── Deploy backfill job (run manually via gcloud) ───────────
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -124,9 +124,12 @@ verifies write quiescence itself:
      --substitutions=_TAG="$DEPLOY_SHA",_CONFIRM_WRITE_QUIESCENCE=true
    ```
 
-2. The build removes public backend invocation, routes traffic to a non-writing
-   maintenance revision, pauses reconciliation if present, verifies no active worker,
-   and waits beyond the old request timeout before migration.
+2. The build first runs the migration job in preflight-only mode. It verifies the
+   exact ledger and the migration role's database/schema privileges without applying
+   migrations, so external permission drift fails before downtime. Only after that
+   passes does the build remove public backend invocation, route traffic to a
+   non-writing maintenance revision, pause reconciliation if present, verify no
+   active worker, and wait beyond the old request timeout before migration.
 3. Route 100% of API traffic to the new revision, confirm old revisions are gone,
    perform the migration 0054/upload/manual-worker-wake smoke checks recorded in
    `docs/architecture-cleanup/current-work.md`, and only then reopen administrative

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -130,6 +130,10 @@ verifies write quiescence itself:
    passes does the build remove public backend invocation, route traffic to a
    non-writing maintenance revision, pause reconciliation if present, verify no
    active worker, and wait beyond the old request timeout before migration.
+
+The deployed migration job also defaults to preflight-only. The controlled and
+automatic release orchestrators explicitly override the job arguments only after
+their migration safety gate passes.
 3. Route 100% of API traffic to the new revision, confirm old revisions are gone,
    perform the migration 0054/upload/manual-worker-wake smoke checks recorded in
    `docs/architecture-cleanup/current-work.md`, and only then reopen administrative

--- a/deploy/cloudrun/backend-migrate-job.yaml
+++ b/deploy/cloudrun/backend-migrate-job.yaml
@@ -24,6 +24,7 @@ spec:
                 - node
               args:
                 - dist/cli/migrate.js
+                - --preflight
               env:
                 - name: NODE_ENV
                   value: production

--- a/deploy/cloudrun/release-full.sh
+++ b/deploy/cloudrun/release-full.sh
@@ -166,6 +166,7 @@ gcloud run jobs replace rendered/cloudrun/backend-migrate-job.yaml \
 gcloud run jobs execute letter-archive-migrate \
   --project="$LETTER_ARCHIVE_PROJECT_ID" \
   --region="$LETTER_ARCHIVE_REGION" \
+  --args=dist/cli/migrate.js \
   --wait
 
 rollback_jobs=true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -150,6 +150,11 @@ Preflight failure leaves the existing public release untouched. If the pipeline
 fails after maintenance begins, the backend remains closed instead of reopening
 an unverified or mixed-version release.
 
+The deployed migration job defaults to `--preflight`. Release orchestration must
+explicitly override its arguments to apply migrations after the relevant
+quiescence or rolling-safety gate, so an ad hoc job execution cannot apply
+maintenance migrations early.
+
 ## External controls
 
 - The legacy `deploy-full` and `deploy-frontend` Cloud Build triggers are

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -130,21 +130,25 @@ explicit maintenance authorization, but it also establishes and verifies the
 maintenance state itself:
 
 1. build and push the exact reviewed release first;
-2. remove the public backend invoker binding;
-3. route backend traffic to a static maintenance revision with no database,
+2. execute the migration image in preflight-only mode to verify the exact
+   ledger, database connection, and schema-creation privilege without applying
+   a migration;
+3. remove the public backend invoker binding;
+4. route backend traffic to a static maintenance revision with no database,
    secret, archive, or worker access;
-4. pause scheduled reconciliation when present;
-5. revoke both API-to-worker and worker self-handoff invocation;
-6. remove the legacy worker pool and wait longer than the old API request
+5. pause scheduled reconciliation when present;
+6. revoke both API-to-worker and worker self-handoff invocation;
+7. remove the legacy worker pool and wait longer than the old API request
    timeout;
-7. require two consecutive observations with no active worker execution;
-8. run migrations in `maintenance` mode;
-9. deploy the new jobs and backend identities;
-10. privately verify backend release identity, DB readiness, and auth status;
-11. reopen the public backend and promote the frontend candidate.
+8. require two consecutive observations with no active worker execution;
+9. run migrations in `maintenance` mode;
+10. deploy the new jobs and backend identities;
+11. privately verify backend release identity, DB readiness, and auth status;
+12. reopen the public backend and promote the frontend candidate.
 
-If the pipeline fails after maintenance begins, the backend remains closed
-instead of reopening an unverified or mixed-version release.
+Preflight failure leaves the existing public release untouched. If the pipeline
+fails after maintenance begins, the backend remains closed instead of reopening
+an unverified or mixed-version release.
 
 ## External controls
 


### PR DESCRIPTION
## Summary
- verify the production migration ledger and database-level schema privilege before entering maintenance
- execute the idempotent Drizzle schema precondition during preflight without applying migrations
- order the controlled bootstrap so permission drift fails while the existing release is still public
- document the preflight and fail-closed boundary

## Production incident addressed
The first controlled bootstrap stopped at the Drizzle schema-creation statement because the dedicated migration role lacked database-level CREATE. The previous public backend revision was restored and verified healthy, and that privilege is now granted only to letter_archive_migrate.

## Validation
- backend: 116 files / 1206 tests
- backend typecheck/build
- architecture contract: 32/32
- Cloud Build YAML parse and diff check

Automatic releases remain disabled until this follow-up is merged and the bootstrap succeeds.