### PR TITLE
Serialize Cloud Run invoker grants

### DIFF
--- a/backend/src/services/__tests__/deployment-release-orchestration.test.ts
+++ b/backend/src/services/__tests__/deployment-release-orchestration.test.ts
@@ -25,6 +25,10 @@ const acquireReleaseLockScript = path.join(
   repositoryRoot,
   'deploy/cloudrun/acquire-release-lock.sh',
 );
+const ensureJobInvokerScript = path.join(
+  repositoryRoot,
+  'deploy/cloudrun/ensure-job-invoker.sh',
+);
 const temporaryDirectories: string[] = [];
 
 function createTemporaryDirectory(prefix: string): string {
@@ -57,6 +61,158 @@ afterEach(() => {
 });
 
 describe('production release shell orchestration', () => {
+  it('retries and verifies Cloud Run job invoker IAM updates', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-job-invoker-',
+    );
+    const fakeBin = path.join(temporaryRoot, 'bin');
+    mkdirSync(fakeBin);
+
+    const statePath = path.join(temporaryRoot, 'gcloud-state.json');
+    writeFileSync(statePath, JSON.stringify({ addAttempts: 0, reads: 0 }));
+
+    writeExecutable(fakeBin, 'sleep', '#!/usr/bin/env node\n');
+    writeExecutable(fakeBin, 'gcloud', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GCLOUD_STATE;
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+
+if (args.slice(0, 3).join(' ') === 'run jobs get-iam-policy') {
+  state.reads += 1;
+  fs.writeFileSync(statePath, JSON.stringify(state));
+  const members = state.addAttempts >= 2
+    ? ['serviceAccount:worker@test-project.iam.gserviceaccount.com']
+    : [];
+  process.stdout.write(JSON.stringify({
+    bindings: [{ role: 'roles/run.invoker', members }],
+  }));
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'run jobs add-iam-policy-binding') {
+  const expected = [
+    'run',
+    'jobs',
+    'add-iam-policy-binding',
+    'letter-archive-worker',
+    '--project=test-project',
+    '--region=us-east1',
+    '--member=serviceAccount:worker@test-project.iam.gserviceaccount.com',
+    '--role=roles/run.invoker',
+    '--quiet',
+  ];
+  if (JSON.stringify(args) !== JSON.stringify(expected)) {
+    process.stderr.write('Unexpected IAM arguments: ' + args.join(' ') + '\\n');
+    process.exit(97);
+  }
+  state.addAttempts += 1;
+  fs.writeFileSync(statePath, JSON.stringify(state));
+  process.exit(state.addAttempts === 1 ? 9 : 0);
+}
+
+process.stderr.write('Unexpected fake gcloud call: ' + args.join(' ') + '\\n');
+process.exit(98);
+`);
+
+    const result = spawnSync('bash', [ensureJobInvokerScript], {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_GCLOUD_STATE: statePath,
+        LETTER_ARCHIVE_PROJECT_ID: 'test-project',
+        LETTER_ARCHIVE_REGION: 'us-east1',
+        LETTER_ARCHIVE_JOB_NAME: 'letter-archive-worker',
+        LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT:
+          'worker@test-project.iam.gserviceaccount.com',
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual({
+      addAttempts: 2,
+      reads: 3,
+    });
+  });
+
+  it('fails closed when a Cloud Run job invoker binding never appears', () => {
+    const temporaryRoot = createTemporaryDirectory(
+      'letter-archive-job-invoker-exhausted-',
+    );
+    const fakeBin = path.join(temporaryRoot, 'bin');
+    mkdirSync(fakeBin);
+
+    const statePath = path.join(temporaryRoot, 'gcloud-state.json');
+    writeFileSync(statePath, JSON.stringify({ addAttempts: 0 }));
+
+    writeExecutable(fakeBin, 'sleep', '#!/usr/bin/env node\n');
+    writeExecutable(fakeBin, 'gcloud', `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GCLOUD_STATE;
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+
+if (args.slice(0, 3).join(' ') === 'run jobs get-iam-policy') {
+  process.stdout.write(JSON.stringify({ bindings: [] }));
+  process.exit(0);
+}
+
+if (args.slice(0, 3).join(' ') === 'run jobs add-iam-policy-binding') {
+  state.addAttempts += 1;
+  fs.writeFileSync(statePath, JSON.stringify(state));
+  process.exit(0);
+}
+
+process.stderr.write('Unexpected fake gcloud call: ' + args.join(' ') + '\\n');
+process.exit(98);
+`);
+
+    const result = spawnSync('bash', [ensureJobInvokerScript], {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_GCLOUD_STATE: statePath,
+        LETTER_ARCHIVE_PROJECT_ID: 'test-project',
+        LETTER_ARCHIVE_REGION: 'us-east1',
+        LETTER_ARCHIVE_JOB_NAME: 'letter-archive-worker',
+        LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT:
+          'worker@test-project.iam.gserviceaccount.com',
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Failed to verify serviceAccount:worker@test-project.iam.gserviceaccount.com on letter-archive-worker',
+    );
+    expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual({
+      addAttempts: 5,
+    });
+  });
+
+  it('rejects job invoker identities outside the release project', () => {
+    const result = spawnSync('bash', [ensureJobInvokerScript], {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        LETTER_ARCHIVE_PROJECT_ID: 'test-project',
+        LETTER_ARCHIVE_REGION: 'us-east1',
+        LETTER_ARCHIVE_JOB_NAME: 'letter-archive-worker',
+        LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT:
+          'worker@other-project.iam.gserviceaccount.com',
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Invoker service account is invalid for the release project',
+    );
+  });
+
   it('rolls back and probes the previous revision after an ambiguous promotion failure', () => {
     const temporaryRoot = createTemporaryDirectory(
       'letter-archive-promotion-rollback-',

--- a/backend/src/services/__tests__/deployment-release-orchestration.test.ts
+++ b/backend/src/services/__tests__/deployment-release-orchestration.test.ts
@@ -79,6 +79,19 @@ const statePath = process.env.FAKE_GCLOUD_STATE;
 const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
 
 if (args.slice(0, 3).join(' ') === 'run jobs get-iam-policy') {
+  const expected = [
+    'run',
+    'jobs',
+    'get-iam-policy',
+    'letter-archive-worker',
+    '--project=test-project',
+    '--region=us-east1',
+    '--format=json',
+  ];
+  if (JSON.stringify(args) !== JSON.stringify(expected)) {
+    process.stderr.write('Unexpected policy read arguments: ' + args.join(' ') + '\\n');
+    process.exit(96);
+  }
   state.reads += 1;
   fs.writeFileSync(statePath, JSON.stringify(state));
   const members = state.addAttempts >= 2
@@ -155,6 +168,19 @@ const statePath = process.env.FAKE_GCLOUD_STATE;
 const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
 
 if (args.slice(0, 3).join(' ') === 'run jobs get-iam-policy') {
+  const expected = [
+    'run',
+    'jobs',
+    'get-iam-policy',
+    'letter-archive-worker',
+    '--project=test-project',
+    '--region=us-east1',
+    '--format=json',
+  ];
+  if (JSON.stringify(args) !== JSON.stringify(expected)) {
+    process.stderr.write('Unexpected policy read arguments: ' + args.join(' ') + '\\n');
+    process.exit(96);
+  }
   process.stdout.write(JSON.stringify({ bindings: [] }));
   process.exit(0);
 }

--- a/backend/src/services/__tests__/processing-ownership.architecture.test.ts
+++ b/backend/src/services/__tests__/processing-ownership.architecture.test.ts
@@ -229,6 +229,15 @@ describe('processing execution ownership', () => {
     expect(controlledDeploy).toMatch(
       /id: deploy-backend[\s\S]*?waitFor:[\s\S]*?- grant-backend-worker-job-invoke/,
     );
+    expect(controlledDeploy).toMatch(
+      /id: grant-backend-worker-job-invoke[\s\S]*?deploy\/cloudrun\/ensure-job-invoker\.sh[\s\S]*?waitFor: \['deploy-worker'\]/,
+    );
+    expect(controlledDeploy).toMatch(
+      /id: grant-worker-handoff-job-invoke[\s\S]*?deploy\/cloudrun\/ensure-job-invoker\.sh[\s\S]*?waitFor: \['grant-backend-worker-job-invoke'\]/,
+    );
+    expect(controlledDeploy).toMatch(
+      /id: grant-scheduler-worker-job-invoke[\s\S]*?deploy\/cloudrun\/ensure-job-invoker\.sh[\s\S]*?waitFor: \['grant-worker-handoff-job-invoke'\]/,
+    );
 
     const workerDeploy = controlledDeploy.indexOf('id: deploy-worker');
     const backendWorkerGrant = controlledDeploy.indexOf(
@@ -394,22 +403,22 @@ describe('processing execution ownership', () => {
     expect(scheduleStep).toBeGreaterThan(schedulerGrant);
 
     expect(controlledDeploy.slice(backendGrant, schedulerGrant)).toContain(
-      '--member=serviceAccount:${_BACKEND_SERVICE_ACCOUNT}',
+      'LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT=${_BACKEND_SERVICE_ACCOUNT}',
     );
     expect(controlledDeploy.slice(backendGrant, schedulerGrant)).toContain(
-      '--role=roles/run.invoker',
+      'deploy/cloudrun/ensure-job-invoker.sh',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
-      '--member="serviceAccount:$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}"',
+      'export LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT="$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}"',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
-      '--role=roles/run.invoker',
+      'bash deploy/cloudrun/ensure-job-invoker.sh',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
       'if [[ "$${LETTER_ARCHIVE_ENABLE_SCHEDULER}" != "true" ]]',
     );
     expect(controlledDeploy.slice(schedulerGrant, scheduleStep)).toContain(
-      "waitFor: ['grant-backend-worker-job-invoke']",
+      "waitFor: ['grant-worker-handoff-job-invoke']",
     );
 
     const scheduleContract = controlledDeploy.slice(scheduleStep);

--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -269,29 +269,27 @@ steps:
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: grant-backend-worker-job-invoke
-    entrypoint: gcloud
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_JOB_NAME=letter-archive-worker'
+      - 'LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT=${_BACKEND_SERVICE_ACCOUNT}'
     args:
-      - run
-      - jobs
-      - add-iam-policy-binding
-      - letter-archive-worker
-      - --region=${_REGION}
-      - --member=serviceAccount:${_BACKEND_SERVICE_ACCOUNT}
-      - --role=roles/run.invoker
+      - deploy/cloudrun/ensure-job-invoker.sh
     waitFor: ['deploy-worker']
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: grant-worker-handoff-job-invoke
-    entrypoint: gcloud
+    entrypoint: bash
+    env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
+      - 'LETTER_ARCHIVE_REGION=${_REGION}'
+      - 'LETTER_ARCHIVE_JOB_NAME=letter-archive-worker'
+      - 'LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT=${_WORKER_SERVICE_ACCOUNT}'
     args:
-      - run
-      - jobs
-      - add-iam-policy-binding
-      - letter-archive-worker
-      - --region=${_REGION}
-      - --member=serviceAccount:${_WORKER_SERVICE_ACCOUNT}
-      - --role=roles/run.invoker
-    waitFor: ['deploy-worker']
+      - deploy/cloudrun/ensure-job-invoker.sh
+    waitFor: ['grant-backend-worker-job-invoke']
 
   # The backend's startup reconciler can invoke the worker job. Declare and
   # authorize that job before starting the new backend revision.
@@ -373,6 +371,7 @@ steps:
     id: grant-scheduler-worker-job-invoke
     entrypoint: bash
     env:
+      - 'LETTER_ARCHIVE_PROJECT_ID=${PROJECT_ID}'
       - 'LETTER_ARCHIVE_ENABLE_SCHEDULER=${_ENABLE_WORKER_RECONCILIATION_SCHEDULE}'
       - 'LETTER_ARCHIVE_REGION=${_REGION}'
       - 'LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT=${_SCHEDULER_SERVICE_ACCOUNT}'
@@ -384,11 +383,10 @@ steps:
           echo "Scheduled worker reconciliation remains disabled for this deployment."
           exit 0
         fi
-        gcloud run jobs add-iam-policy-binding letter-archive-worker \
-          --region="$${LETTER_ARCHIVE_REGION}" \
-          --member="serviceAccount:$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}" \
-          --role=roles/run.invoker
-    waitFor: ['grant-backend-worker-job-invoke']
+        export LETTER_ARCHIVE_JOB_NAME=letter-archive-worker
+        export LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT="$${LETTER_ARCHIVE_SCHEDULER_SERVICE_ACCOUNT}"
+        bash deploy/cloudrun/ensure-job-invoker.sh
+    waitFor: ['grant-worker-handoff-job-invoke']
 
   # Cloud Scheduler calls the asynchronous Cloud Run jobs.run API. The worker's
   # database execution lease, not Scheduler delivery, serializes executions.

--- a/deploy/cloudrun/ensure-job-invoker.sh
+++ b/deploy/cloudrun/ensure-job-invoker.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  LETTER_ARCHIVE_PROJECT_ID
+  LETTER_ARCHIVE_REGION
+  LETTER_ARCHIVE_JOB_NAME
+  LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT
+)
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing job invoker value: $variable_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$LETTER_ARCHIVE_PROJECT_ID" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+  echo "Project ID is invalid" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_REGION" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]]; then
+  echo "Region is invalid" >&2
+  exit 1
+fi
+if [[ ! "$LETTER_ARCHIVE_JOB_NAME" =~ ^letter-archive-[a-z0-9-]+$ ]]; then
+  echo "Cloud Run job name is outside the Letter Archive scope" >&2
+  exit 1
+fi
+service_account_pattern="^[a-z][a-z0-9-]{4,28}[a-z0-9]@${LETTER_ARCHIVE_PROJECT_ID}\\.iam\\.gserviceaccount\\.com$"
+if [[ ! "$LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT" =~ $service_account_pattern ]]; then
+  echo "Invoker service account is invalid for the release project" >&2
+  exit 1
+fi
+
+expected_member="serviceAccount:${LETTER_ARCHIVE_INVOKER_SERVICE_ACCOUNT}"
+
+binding_exists() {
+  gcloud run jobs get-iam-policy "$LETTER_ARCHIVE_JOB_NAME" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --format=json \
+    | LETTER_ARCHIVE_EXPECTED_MEMBER="$expected_member" python3 -c '
+import json
+import os
+import sys
+
+policy = json.load(sys.stdin)
+expected = os.environ["LETTER_ARCHIVE_EXPECTED_MEMBER"]
+for binding in policy.get("bindings", []):
+    if binding.get("role") == "roles/run.invoker" and expected in binding.get("members", []):
+        raise SystemExit(0)
+raise SystemExit(1)
+'
+}
+
+if binding_exists; then
+  echo "$expected_member can already invoke $LETTER_ARCHIVE_JOB_NAME"
+  exit 0
+fi
+
+for attempt in 1 2 3 4 5; do
+  gcloud run jobs add-iam-policy-binding "$LETTER_ARCHIVE_JOB_NAME" \
+    --project="$LETTER_ARCHIVE_PROJECT_ID" \
+    --region="$LETTER_ARCHIVE_REGION" \
+    --member="$expected_member" \
+    --role=roles/run.invoker \
+    --quiet || true
+
+  if binding_exists; then
+    echo "Verified $expected_member can invoke $LETTER_ARCHIVE_JOB_NAME"
+    exit 0
+  fi
+
+  if [[ "$attempt" -lt 5 ]]; then
+    echo "IAM binding retry $attempt/5 ($LETTER_ARCHIVE_JOB_NAME)"
+    sleep "$((attempt * 2))"
+  fi
+done
+
+echo "Failed to verify $expected_member on $LETTER_ARCHIVE_JOB_NAME" >&2
+exit 1


### PR DESCRIPTION
## Summary
- serialize worker invoker IAM mutations in the controlled release graph
- retry each scoped IAM mutation and verify the live policy before continuing
- add exact-argument, exhaustion, scope, and dependency-order regression tests

## Why
The controlled production bootstrap exposed a Cloud Run IAM read-modify-write race when backend and worker invoker bindings ran in parallel. Migrations had succeeded, but the concurrent policy write aborted the remaining deployment. The release was safely completed forward; this change prevents that failure mode before automatic releases are enabled.

## Validation
- backend: 116 files / 1,208 tests passed
- frontend: 155 files / 1,098 tests passed
- focused release tests: 39 passed
- backend typecheck passed
- frontend production build passed
- shell syntax, YAML parse, and git diff checks passed
- independent security and release-integrity reviews clean

SpecFinder is not referenced or modified.