### PR TITLE
Load hosted fonts without inline script

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,15 +19,7 @@
     <link
       href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap"
       rel="stylesheet"
-      media="print"
-      onload="this.media='all'"
     />
-    <noscript>
-      <link
-        href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap"
-        rel="stylesheet"
-      />
-    </noscript>
 
     <title>Voices That Remain</title>
     <meta name="description" content="A digital archive of personal letters and historical correspondence, preserved for future generations." />

--- a/frontend/src/test/csp-static-markup.test.ts
+++ b/frontend/src/test/csp-static-markup.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("static markup CSP compatibility", () => {
+  it("loads hosted fonts without inline event handlers", async () => {
+    const frontendRoot = path.resolve(process.cwd());
+    const [html, securityHeaders] = await Promise.all([
+      readFile(path.join(frontendRoot, "index.html"), "utf8"),
+      readFile(path.join(frontendRoot, "security-headers.conf"), "utf8"),
+    ]);
+
+    expect(securityHeaders).toContain("script-src 'self'");
+    expect(securityHeaders).not.toContain("script-src 'self' 'unsafe-inline'");
+    expect(securityHeaders).toContain(
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    );
+    expect(securityHeaders).toContain("font-src 'self' data: https:");
+
+    const document = new DOMParser().parseFromString(html, "text/html");
+    const googleFontStylesheets = [
+      ...document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'),
+    ].filter((link) =>
+      link.getAttribute("href")?.startsWith(
+        "https://fonts.googleapis.com/css2?",
+      ),
+    );
+    expect(googleFontStylesheets).toHaveLength(1);
+    expect(googleFontStylesheets[0]?.getAttribute("media")).not.toBe("print");
+    expect(googleFontStylesheets[0]?.hasAttribute("onload")).toBe(false);
+
+    expect(html).not.toMatch(/\son[a-z]+\s*=/i);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the CSP-blocked inline font `onload` handler with a normal stylesheet link
- remove the now-redundant noscript duplicate
- add a regression test covering the exact Google Fonts stylesheet and deployed CSP directives

## Why
The final hosted browser check found production CSP blocking `onload="this.media=\all\"`. That could leave the redesigned UI on fallback fonts even though the correct frontend SHA was deployed.\n\n## Validation\n- focused CSP regression test passed\n- frontend TypeScript build passed\n- frontend production build passed\n- existing frontend suite: 155 files / 1,098 existing tests passed\n- independent security and release reviews clean\n\nSpecFinder is not referenced or modified.