### PR TITLE
Stop auto-opening segment review

### DIFF
--- a/e2e/tests/line-review.mocked.spec.ts
+++ b/e2e/tests/line-review.mocked.spec.ts
@@ -17,21 +17,10 @@ async function openLineReview(
   });
   await page.goto(`/admin/letters/${initialLetter.id}`);
   await page.locator('.letter-review-page').waitFor({ state: 'visible' });
-
-  // Letters with stored line segments auto-enter segment-first review mode, so
-  // .viewer-image is never shown — wait directly for line-review-mode in that case.
-  const hasStoredSegments = initialLetter.images.some(
-    (img) => Array.isArray(img.lineSegments) && img.lineSegments.length > 0,
-  );
-
-  if (!hasStoredSegments) {
-    await page.locator('.viewer-image').waitFor({ state: 'visible' });
-    await page.locator('.viewer-image').click();
-  }
+  await page.locator('.viewer-image').waitFor({ state: 'visible' });
+  await page.locator('.viewer-image').click();
   await page.locator('.line-review-mode').waitFor({ state: 'visible' });
-  await page.locator(
-    hasStoredSegments ? '.seg-editor-actions' : '.line-review-input-overlay',
-  ).waitFor({ state: 'visible' });
+  await page.locator('.line-review-input-overlay').waitFor({ state: 'visible' });
   return mockedApi;
 }
 
@@ -42,6 +31,7 @@ function createLetterWithStoredLineSegments() {
   return createMockLetterReviewLetter({
     images: initialLetter.images.map((image) => ({
       ...image,
+      segmentTrustState: 'unverified',
       lineSegments: detectLinesByPageId[image.id]?.lineSegments ?? [],
     })),
   });
@@ -74,6 +64,25 @@ test.describe('@mocked Line Review', () => {
     await expect(page.locator('.line-review-editable')).toContainText(
       'The weather has been kind.',
     );
+  });
+
+  test('keeps stored unverified segments on the split review until the image is clicked', async ({
+    page,
+  }) => {
+    const initialLetter = createLetterWithStoredLineSegments();
+    await installMockLetterReviewApi(page, { initialLetter });
+
+    await page.goto(`/admin/letters/${initialLetter.id}`);
+    await page.locator('.letter-review-page').waitFor({ state: 'visible' });
+
+    await expect(page.locator('.viewer-image')).toBeVisible();
+    await expect(page.locator('.transcript-editor')).toBeVisible();
+    await expect(page.locator('.line-review-mode')).toHaveCount(0);
+
+    await page.locator('.viewer-image').click();
+
+    await expect(page.locator('.line-review-mode')).toBeVisible();
+    await expect(page.locator('.line-review-input-overlay')).toBeVisible();
   });
 
   test('starts a fresh review shell when navigating to another letter', async ({
@@ -194,6 +203,9 @@ test.describe('@mocked Line Review', () => {
   }) => {
     const initialLetter = createLetterWithStoredLineSegments();
     const mockedApi = await openLineReview(page, initialLetter);
+
+    await page.getByRole('button', { name: 'Segments', exact: true }).click();
+    await expect(page.locator('.seg-editor-actions')).toBeVisible();
 
     await page.locator('.segment-editor-rect').first().dispatchEvent(
       'pointerdown',

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -120,8 +120,7 @@ test.describe('Navigation', () => {
       await firstRow.locator('[data-column="sender"]').click();
       await page.waitForURL(/\/admin\/letters\//);
 
-      // Browser history remains available even if the selected letter opens a
-      // full-screen review surface that intentionally blocks sidebar clicks.
+      // Exercise route-level back navigation from the normal letter review.
       await page.goBack();
       await page.waitForURL(/\/admin$/);
       expect(page.url()).toMatch(/\/admin$/);

--- a/frontend/src/pages/admin/LetterReview/__tests__/useLineReviewWorkspace.test.tsx
+++ b/frontend/src/pages/admin/LetterReview/__tests__/useLineReviewWorkspace.test.tsx
@@ -430,71 +430,60 @@ describe('useLineReviewWorkspace', () => {
     expect(reloadFreshA).toHaveBeenCalledOnce();
   });
 
-  it('auto-enters segment-first mode at most once for each opaque visit', () => {
+  it('keeps stored segments closed until an explicit entry action', () => {
     const firstAActive = { current: true };
-    const bActive = { current: false };
     const freshAActive = { current: false };
     const visits = {
       firstA: visit('letter-a', firstAActive),
-      b: visit('letter-b', bActive),
       freshA: visit('letter-a', freshAActive),
     };
-    const eligibleA = makeEligibleLetter();
     const initialProps = baseProps(visits.firstA, {
-      letter: eligibleA,
+      letter: null,
     });
     const { result, rerender } = renderHook(useWorkspace, {
       initialProps,
     });
 
-    expect(result.current.active).toBe(true);
-    expect(result.current.modeProps.fullViewport).toBe(true);
+    expect(result.current.active).toBe(false);
+    expect(result.current.modeProps.fullViewport).toBe(false);
     expect(result.current.modeProps.mappingText).toBeUndefined();
 
-    act(() => {
-      result.current.modeProps.onExit();
+    rerender({
+      ...initialProps,
+      letter: makeEligibleLetter(),
     });
     expect(result.current.active).toBe(false);
+    expect(result.current.modeProps.fullViewport).toBe(false);
+    expect(result.current.modeProps.mappingText).toBeUndefined();
 
     rerender({
       ...initialProps,
       letter: makeEligibleLetter({
-        title: 'Updated Letter A',
+        title: 'Refreshed Letter A',
+        primarySourceRevision: 4,
       }),
     });
     expect(result.current.active).toBe(false);
+    expect(result.current.modeProps.fullViewport).toBe(false);
+    expect(result.current.modeProps.mappingText).toBeUndefined();
 
     firstAActive.current = false;
-    bActive.current = true;
-    rerender({
-      ...initialProps,
-      currentVisit: visits.b,
-      letter: makeLetter({
-        id: 'letter-b',
-        title: 'Letter B',
-      }),
-    });
-    expect(result.current.active).toBe(false);
-
-    rerender({
-      ...initialProps,
-      currentVisit: visits.b,
-      letter: makeEligibleLetter({
-        id: 'letter-b',
-        title: 'Letter B with later segments',
-      }),
-    });
-    expect(result.current.active).toBe(false);
-
-    bActive.current = false;
     freshAActive.current = true;
     rerender({
       ...initialProps,
       currentVisit: visits.freshA,
       letter: makeEligibleLetter(),
     });
+    expect(result.current.active).toBe(false);
+    expect(result.current.modeProps.fullViewport).toBe(false);
+    expect(result.current.modeProps.mappingText).toBeUndefined();
+
+    act(() => {
+      result.current.viewerProps.onImageClick(0);
+    });
     expect(result.current.active).toBe(true);
-    expect(result.current.modeProps.fullViewport).toBe(true);
+    expect(result.current.modeProps.fullViewport).toBe(false);
+    expect(result.current.modeProps.mappingText).toBeUndefined();
   });
 
   it('refreshes and adopts the current letter after mapping, and catches refresh failures', async () => {

--- a/frontend/src/pages/admin/LetterReview/useLineReviewWorkspace.ts
+++ b/frontend/src/pages/admin/LetterReview/useLineReviewWorkspace.ts
@@ -55,7 +55,6 @@ interface LineReviewSession {
   viewerPageIndex: number;
   debugMode: boolean;
   selectedText: string;
-  segmentFirstEvaluated: boolean;
 }
 
 interface OwnedModeHandle {
@@ -100,16 +99,7 @@ const sessionFrom = (owner: LetterReviewVisit): LineReviewSession => ({
   viewerPageIndex: 0,
   debugMode: false,
   selectedText: '',
-  segmentFirstEvaluated: false,
 });
-
-const hasUnverifiedSegments = (letter: Letter): boolean =>
-  letter.images.some((image) => (
-    image.type === 'letter'
-    && image.segmentTrustState !== 'trusted'
-    && Array.isArray(image.lineSegments)
-    && image.lineSegments.length > 0
-  ));
 
 const validPageIndex = (
   letter: Letter | null,
@@ -185,45 +175,10 @@ export function useLineReviewWorkspace({
   ) => {
     if (!visit.isActive()) return;
 
-    setStoredSession((current) => (
-      current.owner === visit
-        ? update(current)
-        : current
-    ));
-  }, [visit]);
-
-  const establishSession = useCallback((
-    update: (current: LineReviewSession) => LineReviewSession,
-  ) => {
-    if (!visit.isActive()) return;
-
     setStoredSession((current) => update(
       current.owner === visit ? current : sessionFrom(visit),
     ));
   }, [visit]);
-
-  useEffect(() => {
-    if (!letter || !visit.isActive()) return;
-
-    // This finite transition records that the authoritative letter was
-    // evaluated once; subsequent DTO refreshes must not reopen the mode.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- DTO arrival establishes one owner-tagged session transition.
-    establishSession((current) => {
-      if (current.segmentFirstEvaluated) return current;
-
-      return {
-        ...current,
-        entry: hasUnverifiedSegments(letter)
-          ? {
-              kind: 'segment-first',
-              owner: entryOwnerFrom(visit),
-              mappingText: undefined,
-            }
-          : current.entry,
-        segmentFirstEvaluated: true,
-      };
-    });
-  }, [establishSession, letter, visit]);
 
   useEffect(() => {
     const clearSelection = () => {


### PR DESCRIPTION
## What changed

- remove the letter-DTO effect that automatically opened fullscreen segment review when stored unverified segments were present
- keep normal image-click review, explicit Review, and Map to Segment entry paths intact
- add hook coverage for initial load, DTO arrival/refresh, fresh visits, and explicit image entry
- update mocked browser coverage so stored segments stay on the normal split review until an explicit action

## Why

Opening an admin letter should first show the ordinary letter review workspace. Segment review is a specialized tool and should only take over after the archivist clicks the image or chooses an explicit segment action.

## Verification

- Hook regression suite: 10/10 passed
- Mocked Line Review Playwright suite: 10/10 passed
- Frontend production build and TypeScript check: passed
- Targeted ESLint: passed
- Two independent code/test reviews: no blocking findings
- Full frontend suite: 1,098/1,099 passed; one unrelated SearchBar timing test exceeded its 5-second limit and passed immediately when rerun with the changed hook suite
- git diff --check: passed