### PR TITLE
Protect unsaved review edits when navigating away

### DIFF
--- a/docs/site-improvements/progress.md
+++ b/docs/site-improvements/progress.md
@@ -1,0 +1,27 @@
+# Site improvements — September 2026
+
+## Scope
+
+Work begins from origin/main at 11280b24 in an isolated checkout. The original
+rotated-region-recovery checkout and uncommitted handwriting work are excluded.
+The research-only placement fixture, native Python test, and lab transport findings
+from the audit are not present on this baseline and will not be imported.
+
+## Delivery policy
+
+One focused PR per fix. Required CI checks must pass before merge. Inspect review
+comments and resulting production release; measure affected behavior. Never force
+merge or weaken a test to hide a failure. Record deferred product decisions.
+
+## Work
+
+| Fix | Verification | Delivery |
+| --- | --- | --- |
+| Protect pending review autosaves on navigation and document exit | Browser checks cover saved notes and failed-save retention; hook checks cover waiting and exit warning; production build passes | PR pending |
+
+## Next
+
+Fatal API lifecycle; shared public ordering/date ranges; bounded data and image
+loading; navigation cache recovery; truthful settings/link semantics/loading UX;
+public initial metadata; dependency and CI hygiene. Product-specific content and
+unavailable donation/contact setup remain deferred.

--- a/e2e/tests/letter-review.mocked.spec.ts
+++ b/e2e/tests/letter-review.mocked.spec.ts
@@ -126,6 +126,9 @@ test.describe('@mocked Letter Review', () => {
     await expect(page.locator('.toast')).toContainText('Database offline');
     await expect(page).toHaveURL(new RegExp(`/admin/letters/${letter.id}$`));
     await expect(page.getByLabel('Personal Notes')).toHaveValue('Do not discard this note');
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('link', { name: 'Voices That Remain Admin' }).click();
+    await expect(page).toHaveURL(/\/admin$/);
   });
 
   test('shows the request id when the review page fails to load', async ({ page }) => {

--- a/e2e/tests/letter-review.mocked.spec.ts
+++ b/e2e/tests/letter-review.mocked.spec.ts
@@ -106,6 +106,28 @@ function createMockLetterWithExtras(
 }
 
 test.describe('@mocked Letter Review', () => {
+  test('flushes personal notes before leaving review', async ({ page }) => {
+    const api = await openMockLetterReview(page);
+    await page.getByLabel('Personal Notes').fill('Keep this note on navigation');
+    await page.getByRole('link', { name: 'Voices That Remain Admin' }).click();
+    await expect(page).toHaveURL(/\/admin$/);
+    expect(api.updateLetterRequests.some((request) =>
+      request.body.notes === 'Keep this note on navigation',
+    )).toBe(true);
+  });
+
+  test('keeps review open when saving notes before navigation fails', async ({ page }) => {
+    const letter = createMockLetterReviewLetter();
+    await openMockLetterReviewWithOptions(page, letter, {
+      routeFailures: { updateLetter: { status: 503, error: 'Database offline' } },
+    });
+    await page.getByLabel('Personal Notes').fill('Do not discard this note');
+    await page.getByRole('link', { name: 'Voices That Remain Admin' }).click();
+    await expect(page.locator('.toast')).toContainText('Database offline');
+    await expect(page).toHaveURL(new RegExp(`/admin/letters/${letter.id}$`));
+    await expect(page.getByLabel('Personal Notes')).toHaveValue('Do not discard this note');
+  });
+
   test('shows the request id when the review page fails to load', async ({ page }) => {
     const initialLetter = createMockLetterReviewLetter();
     await installMockLetterReviewApi(page, {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useCallback } from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Routes, Route } from "react-router-dom";
 import Header from "./components/Header/Header";
 import ScrollToTop from "./components/ScrollToTop";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -42,7 +42,7 @@ function RouteLoading() {
   );
 }
 
-function App() {
+function AppRoutes() {
   // Registers the public-site scroll container with the appScroll helper
   // module. See utils/appScroll.ts and the scroll-container refactor (#35)
   // for background on why scroll lives on a child div instead of window.
@@ -51,8 +51,7 @@ function App() {
   }, []);
 
   return (
-    <ErrorBoundary>
-    <Router>
+    <>
       <ScrollToTop />
       <Suspense fallback={<RouteLoading />}>
         <Routes>
@@ -107,9 +106,15 @@ function App() {
           />
         </Routes>
       </Suspense>
-    </Router>
-    </ErrorBoundary>
+    </>
   );
 }
 
-export default App;
+const router = createBrowserRouter([{
+  path: "*",
+  element: <ErrorBoundary><AppRoutes /></ErrorBoundary>,
+}]);
+
+export default function App() {
+  return <RouterProvider router={router} />;
+}

--- a/frontend/src/pages/admin/LetterReview/__tests__/useReviewNavigationGuard.test.tsx
+++ b/frontend/src/pages/admin/LetterReview/__tests__/useReviewNavigationGuard.test.tsx
@@ -1,0 +1,42 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider, Link } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { useReviewNavigationGuard } from '../useReviewNavigationGuard';
+
+function Review({ pending, flush }: { pending: boolean; flush: () => Promise<boolean> }) {
+  useReviewNavigationGuard(pending, flush);
+  return <Link to="/next">Leave review</Link>;
+}
+
+describe('review navigation protection', () => {
+  it('waits for a successful flush before unmounting the editor', async () => {
+    let finish!: (saved: boolean) => void;
+    const flush = vi.fn(() => new Promise<boolean>((resolve) => { finish = resolve; }));
+    const router = createMemoryRouter([
+      { path: '/', element: <Review pending flush={flush} /> },
+      { path: '/next', element: <p>Next page</p> },
+    ]);
+    render(<RouterProvider router={router} />);
+    act(() => { screen.getByText('Leave review').click(); });
+    await waitFor(() => expect(flush).toHaveBeenCalledOnce());
+    expect(screen.queryByText('Next page')).toBeNull();
+    await act(async () => { finish(true); });
+    expect(await screen.findByText('Next page')).toBeVisible();
+  });
+
+  it('warns on document exit only while there are unsaved edits', () => {
+    const flush = vi.fn(async () => true);
+    const router = createMemoryRouter([{ path: '/', element: <Review pending flush={flush} /> }]);
+    const view = render(<RouterProvider router={router} />);
+    const event = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(flush).not.toHaveBeenCalled();
+    view.unmount();
+    const cleanRouter = createMemoryRouter([{ path: '/', element: <Review pending={false} flush={flush} /> }]);
+    render(<RouterProvider router={cleanRouter} />);
+    const cleanExit = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(cleanExit);
+    expect(cleanExit.defaultPrevented).toBe(false);
+  });
+});

--- a/frontend/src/pages/admin/LetterReview/__tests__/useReviewNavigationGuard.test.tsx
+++ b/frontend/src/pages/admin/LetterReview/__tests__/useReviewNavigationGuard.test.tsx
@@ -24,6 +24,21 @@ describe('review navigation protection', () => {
     expect(await screen.findByText('Next page')).toBeVisible();
   });
 
+  it('allows explicit discard after a failed lane cannot be flushed', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValueOnce(false).mockReturnValueOnce(true);
+    const router = createMemoryRouter([
+      { path: '/', element: <Review pending flush={async () => false} /> },
+      { path: '/next', element: <p>Next page</p> },
+    ]);
+    render(<RouterProvider router={router} />);
+    act(() => { screen.getByText('Leave review').click(); });
+    await waitFor(() => expect(confirm).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('Next page')).toBeNull();
+    act(() => { screen.getByText('Leave review').click(); });
+    expect(await screen.findByText('Next page')).toBeVisible();
+    confirm.mockRestore();
+  });
+
   it('warns on document exit only while there are unsaved edits', () => {
     const flush = vi.fn(async () => true);
     const router = createMemoryRouter([{ path: '/', element: <Review pending flush={flush} /> }]);

--- a/frontend/src/pages/admin/LetterReview/useAutoSave.ts
+++ b/frontend/src/pages/admin/LetterReview/useAutoSave.ts
@@ -83,6 +83,7 @@ export function useAutoSave({
   );
   const {
     autoSaveStatus,
+    busyLanes,
     scheduleDebouncedSave,
     flushDebouncedSaves,
     cancelDebouncedSaves: cancelCoordinatorSaves,
@@ -341,6 +342,7 @@ export function useAutoSave({
   ]);
 
   return {
+    hasPendingSaves: busyLanes.size > 0 || autoSaveStatus === 'error',
     autoSaveStatus,
     identityUpdateSecondsRemaining,
     identityUpdateState,

--- a/frontend/src/pages/admin/LetterReview/useReviewNavigationGuard.ts
+++ b/frontend/src/pages/admin/LetterReview/useReviewNavigationGuard.ts
@@ -33,7 +33,10 @@ export function useReviewNavigationGuard(
       try { saved = await current.current.flush(); } catch { /* Stay on the editor. */ }
       const latest = blockerRef.current;
       if (latest.state === 'blocked') {
-        if (saved) latest.proceed();
+        const discard = !saved && window.confirm(
+          'Changes could not be saved. Leave this review and discard unsaved changes?',
+        );
+        if (saved || discard) latest.proceed();
         else latest.reset();
       }
       saving.current = false;

--- a/frontend/src/pages/admin/LetterReview/useReviewNavigationGuard.ts
+++ b/frontend/src/pages/admin/LetterReview/useReviewNavigationGuard.ts
@@ -1,0 +1,42 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+/** Keep the owning review mounted until its queued edits have settled. */
+export function useReviewNavigationGuard(
+  pending: boolean,
+  flush: () => Promise<boolean>,
+) {
+  const current = useRef({ pending, flush });
+  useLayoutEffect(() => { current.current = { pending, flush }; }, [pending, flush]);
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => (
+    current.current.pending && currentLocation.pathname !== nextLocation.pathname
+  ));
+  const saving = useRef(false);
+  const blockerRef = useRef(blocker);
+  useLayoutEffect(() => { blockerRef.current = blocker; }, [blocker]);
+
+  useEffect(() => {
+    const warnOnExit = (event: BeforeUnloadEvent) => {
+      if (!current.current.pending) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', warnOnExit);
+    return () => window.removeEventListener('beforeunload', warnOnExit);
+  }, []);
+
+  useEffect(() => {
+    if (blocker.state !== 'blocked' || saving.current) return;
+    saving.current = true;
+    void (async () => {
+      let saved = false;
+      try { saved = await current.current.flush(); } catch { /* Stay on the editor. */ }
+      const latest = blockerRef.current;
+      if (latest.state === 'blocked') {
+        if (saved) latest.proceed();
+        else latest.reset();
+      }
+      saving.current = false;
+    })();
+  }, [blocker]);
+}

--- a/frontend/src/pages/admin/LetterReviewPage.tsx
+++ b/frontend/src/pages/admin/LetterReviewPage.tsx
@@ -1,3 +1,4 @@
+import { useReviewNavigationGuard } from "./LetterReview/useReviewNavigationGuard";
 import {
   startTransition,
   useState,
@@ -126,6 +127,7 @@ export default function LetterReviewPage() {
   const {
     autoSaveStatus,
     flushPendingSaves,
+    hasPendingSaves,
     identityUpdateSecondsRemaining,
     identityUpdateState,
     retagState,
@@ -140,6 +142,7 @@ export default function LetterReviewPage() {
     mutationsBlocked,
     syncIdentityMetadata,
   });
+  useReviewNavigationGuard(hasPendingSaves, flushPendingSaves);
   const scheduleStatusReset = useLetterReviewStatusResets(visit);
   const photoDescriptionWorkspace = usePhotoDescriptionWorkspace({
     visit,


### PR DESCRIPTION
Leaving Letter Review immediately after typing could cancel its debounced save. Review now waits for queued edits before changing routes, retains the editor on save failure, and warns before document exit while changes remain unsaved.

React Router now uses its data-router wrapper so navigation blocking is owned by the router. Existing route definitions and visit/revision ownership remain intact.

Validation: 157 frontend test files / 1,101 tests passed; production build passed; two real-browser regression checks passed for save-before-navigation and failed-save retention. Hook tests cover an in-flight save and document-exit warnings. No handwriting/research work is included.
