### PR TITLE
Terminate backend processes after fatal errors

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,13 +27,9 @@ import { notify } from './services/notifications.js';
 import { startNotificationSweeper, stopNotificationSweeper } from './services/notification-sweeper.js';
 import { initNotificationStreamBroadcaster } from './routes/admin/notifications-stream.js';
 
-/* ── Process-level error monitoring ─────────────────────── */
-process.on('uncaughtException', (err) => {
-  logger.fatal({ err }, 'UNCAUGHT EXCEPTION');
-});
-process.on('unhandledRejection', (reason) => {
-  logger.error({ reason }, 'UNHANDLED REJECTION');
-});
+import { installFatalErrorLogging } from './utils/fatal-errors.js';
+
+installFatalErrorLogging(logger);
 
 const app = express();
 const LEASE_RECOVERY_INTERVAL_MS = 60_000;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,10 +27,6 @@ import { notify } from './services/notifications.js';
 import { startNotificationSweeper, stopNotificationSweeper } from './services/notification-sweeper.js';
 import { initNotificationStreamBroadcaster } from './routes/admin/notifications-stream.js';
 
-import { installFatalErrorLogging } from './utils/fatal-errors.js';
-
-installFatalErrorLogging(logger);
-
 const app = express();
 const LEASE_RECOVERY_INTERVAL_MS = 60_000;
 

--- a/backend/src/utils/__tests__/fatal-errors.test.ts
+++ b/backend/src/utils/__tests__/fatal-errors.test.ts
@@ -1,0 +1,31 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const exec = promisify(execFile);
+const modulePath = fileURLToPath(new URL('../fatal-errors.ts', import.meta.url));
+
+describe('fatal process errors', () => {
+  for (const trigger of [
+    'setImmediate(() => { throw new Error("fatal fixture"); });',
+    'Promise.reject(new Error("fatal fixture"));',
+  ]) {
+    it(`logs and exits nonzero: ${trigger}`, async () => {
+      const child = await exec(process.execPath, [
+        '--import', 'tsx', '--unhandled-rejections=warn', '--input-type=module', '-e',
+        `import { installFatalErrorLogging } from ${JSON.stringify(modulePath)};
+         installFatalErrorLogging({ fatal: () => process.stderr.write('FATAL_OBSERVED\\n') });
+         setInterval(() => {}, 1000);
+         ${trigger}`,
+      ], { timeout: 5_000 }).then(
+        () => ({ code: 0, stderr: '', killed: false }),
+        (error) => error as { code: number; stderr: string; killed: boolean },
+      );
+      expect(child.killed).toBe(false);
+      expect(child.code).toBe(1);
+      expect(child.stderr).toContain('FATAL_OBSERVED');
+      expect(child.stderr).toContain('fatal fixture');
+    });
+  }
+});

--- a/backend/src/utils/__tests__/fatal-errors.test.ts
+++ b/backend/src/utils/__tests__/fatal-errors.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const exec = promisify(execFile);
-const modulePath = fileURLToPath(new URL('../fatal-errors.ts', import.meta.url));
+const modulePath = fileURLToPath(new URL('../logger.ts', import.meta.url));
 
 describe('fatal process errors', () => {
   for (const trigger of [
@@ -14,17 +14,17 @@ describe('fatal process errors', () => {
     it(`logs and exits nonzero: ${trigger}`, async () => {
       const child = await exec(process.execPath, [
         '--import', 'tsx', '--unhandled-rejections=warn', '--input-type=module', '-e',
-        `import { installFatalErrorLogging } from ${JSON.stringify(modulePath)};
-         installFatalErrorLogging({ fatal: () => process.stderr.write('FATAL_OBSERVED\\n') });
+        `import ${JSON.stringify(modulePath)};
          setInterval(() => {}, 1000);
          ${trigger}`,
-      ], { timeout: 5_000 }).then(
-        () => ({ code: 0, stderr: '', killed: false }),
-        (error) => error as { code: number; stderr: string; killed: boolean },
+      ], { timeout: 5_000, env: { ...process.env, NODE_ENV: 'production', LOG_TO_FILES: 'false' } }).then(
+        () => ({ code: 0, stderr: '', stdout: '', killed: false }),
+        (error) => error as { code: number; stderr: string; stdout: string; killed: boolean },
       );
       expect(child.killed).toBe(false);
       expect(child.code).toBe(1);
-      expect(child.stderr).toContain('FATAL_OBSERVED');
+      const fatalRecords = child.stdout.split('\n').filter((line) => line.includes('CRITICAL'));
+      expect(fatalRecords).toHaveLength(1);
       expect(child.stderr).toContain('fatal fixture');
     });
   }

--- a/backend/src/utils/fatal-errors.ts
+++ b/backend/src/utils/fatal-errors.ts
@@ -1,0 +1,14 @@
+interface FatalLogger {
+  fatal(fields: { err: unknown }, message: string): void;
+}
+
+/** Observe fatal errors without overriding Node's nonzero termination. */
+export function installFatalErrorLogging(log: FatalLogger): void {
+  process.on('uncaughtExceptionMonitor', (err) => {
+    log.fatal({ err }, 'Uncaught exception; terminating process');
+  });
+  // Make rejection termination explicit even if Node was launched in warn mode.
+  process.on('unhandledRejection', (reason) => {
+    throw reason instanceof Error ? reason : new Error('Unhandled rejection', { cause: reason });
+  });
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { installFatalErrorLogging } from './fatal-errors.js';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -286,24 +287,7 @@ export function installProcessLogging(log: pino.Logger = logger): void {
     );
   });
 
-  process.on('unhandledRejection', (reason) => {
-    log.error(
-      {
-        reason,
-      },
-      'Unhandled promise rejection',
-    );
-  });
-
-  process.on('uncaughtExceptionMonitor', (error, origin) => {
-    log.fatal(
-      {
-        err: error,
-        origin,
-      },
-      'Uncaught exception',
-    );
-  });
+  installFatalErrorLogging(log);
 }
 
 installProcessLogging(logger);


### PR DESCRIPTION
The API logged uncaught exceptions but kept serving. Its overriding handler is removed, and the existing once-only process logger now owns fatal-error observation and rejection termination for backend processes. Node exits nonzero so the supervisor can replace a failed process; each failure produces one critical log event.

Normal SIGTERM/SIGINT draining is unchanged. Fatal exceptions do not attempt asynchronous recovery.

Validation: 117 backend test files / 1,211 tests and typecheck passed. Subprocess checks import the real logger and verify one critical event, exit code 1, and no timeout for an exception and an unhandled rejection (including Node warning mode).
