### PR TITLE
Keep public catalogue navigation in a consistent order

### DIFF
--- a/backend/src/routes/collections.ts
+++ b/backend/src/routes/collections.ts
@@ -14,6 +14,7 @@ import {
   toPublicLetter,
 } from '../services/public-read-model.js';
 import {
+  publicCatalogueChronologySql,
   isPhotoOnlyCatalogueUnit,
   publicCatalogueLetterTypeSql,
   retainRowsWithPublicCatalogueRoot,
@@ -217,7 +218,7 @@ router.get('/collections/:code', async (req, res, next) => {
           orderBy: (p, { asc }) => [asc(p.pageNumber)],
         },
       },
-      orderBy: [asc(letters.letterDate)],
+      orderBy: [publicCatalogueChronologySql(letters.dateRaw, letters.collectionId, letters.typeSequence)],
     });
 
     // Group by (dateRaw, typeSequence) to merge companions into primaries.

--- a/backend/src/routes/letters.ts
+++ b/backend/src/routes/letters.ts
@@ -20,6 +20,7 @@ import {
   toPublicLetter,
 } from '../services/public-read-model.js';
 import {
+  publicCatalogueChronologySql,
   isPhotoOnlyCatalogueUnit,
   publicCatalogueLetterTypeSql,
   publicCatalogueRepresentativeOrderSql,
@@ -242,7 +243,9 @@ router.get('/letters', async (req, res, next) => {
           orderBy: (p, { asc: pageAsc }) => [pageAsc(p.pageNumber)],
         },
       },
-      orderBy: [sortFn(getSortExpression())],
+      orderBy: query.sort === 'letterDate'
+        ? [publicCatalogueChronologySql(letters.dateRaw, letters.collectionId, letters.typeSequence, query.sortOrder === 'desc')]
+        : [sortFn(getSortExpression())],
     });
 
     // Group letters by (collectionId, dateRaw, typeSequence) — all types on the
@@ -380,7 +383,9 @@ router.get('/letters/summaries', async (req, res, next) => {
           orderBy: (page, { asc: pageAsc }) => [pageAsc(page.pageNumber)],
         },
       },
-      orderBy: [sortFn(getSortExpression())],
+      orderBy: query.sort === 'letterDate'
+        ? [publicCatalogueChronologySql(letters.dateRaw, letters.collectionId, letters.typeSequence, query.sortOrder === 'desc')]
+        : [sortFn(getSortExpression())],
     });
 
     // Group by (collectionId, dateRaw, typeSequence) — merge companion types
@@ -625,7 +630,7 @@ router.get('/letters/:letterId/adjacent', async (req, res, next) => {
           orderBy: (p, { asc: pageAsc }) => [pageAsc(p.pageNumber)],
         },
       },
-      orderBy: [asc(letters.dateRaw), asc(letters.createdAt)],
+      orderBy: [publicCatalogueChronologySql(letters.dateRaw, letters.collectionId, letters.typeSequence)],
     });
 
     // Deduplicate public catalogue roots by correspondence-unit identity using
@@ -1521,9 +1526,9 @@ function buildArchiveSearchOrderBy(query: ArchiveSearchQuery) {
   const resolvedSort = query.sort === 'relevance' && !hasSearch ? 'createdAt' : query.sort;
 
   if (resolvedSort === 'letterDate') {
-    return query.sortOrder === 'asc'
-      ? sql`REPLACE(sg."dateRaw", 'X', '0') ASC, sg."createdAt" DESC`
-      : sql`REPLACE(sg."dateRaw", 'X', '0') DESC, sg."createdAt" DESC`;
+    return publicCatalogueChronologySql(
+      sql`sg."dateRaw"`, sql`sg."collectionId"`, sql`sg."typeSequence"`, query.sortOrder === 'desc',
+    );
   }
 
   if (resolvedSort === 'createdAt') {

--- a/backend/src/services/__tests__/public-catalogue-unit.test.ts
+++ b/backend/src/services/__tests__/public-catalogue-unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import {
+  publicCatalogueChronologySql,
   PUBLIC_CATALOGUE_LETTER_TYPES,
   isPhotoOnlyCatalogueUnit,
   isPublicCatalogueLetterType,
@@ -13,6 +14,17 @@ import {
 } from '../public-catalogue-unit.js';
 
 describe('public catalogue units', () => {
+  it('uses normalized partial dates and complete unit identity in both directions', () => {
+    const dialect = new PgDialect();
+    for (const descending of [false, true]) {
+      const query = dialect.sqlToQuery(publicCatalogueChronologySql(
+        sql.raw('date_raw'), sql.raw('collection_id'), sql.raw('type_sequence'), descending,
+      ));
+      const direction = descending ? 'DESC' : 'ASC';
+      expect(query.sql).toBe(`REPLACE(date_raw, 'X', '0') ${direction}, date_raw ${direction}, collection_id ${direction}, type_sequence ${direction}`);
+    }
+  });
+
   it('keeps positive catalogue roots and companions from the same unit only', () => {
     const rows = [
       { id: 'root', collectionId: '009', dateRaw: '19470810', typeSequence: '01', type: 'L' },

--- a/backend/src/services/public-catalogue-unit.ts
+++ b/backend/src/services/public-catalogue-unit.ts
@@ -37,6 +37,20 @@ export function publicCatalogueRepresentativeOrderSql(type: SQLWrapper) {
   return sql`array_position(ARRAY[${publicCatalogueLetterTypesSql()}]::letter_type[], ${type})`;
 }
 
+/** Unknown date components sort at the start of their known range.
+ * Unit identity breaks ties, so every public chronological view agrees.
+ */
+export function publicCatalogueChronologySql(
+  dateRaw: SQLWrapper,
+  collectionId: SQLWrapper,
+  typeSequence: SQLWrapper,
+  descending = false,
+) {
+  return descending
+    ? sql`REPLACE(${dateRaw}, 'X', '0') DESC, ${dateRaw} DESC, ${collectionId} DESC, ${typeSequence} DESC`
+    : sql`REPLACE(${dateRaw}, 'X', '0') ASC, ${dateRaw} ASC, ${collectionId} ASC, ${typeSequence} ASC`;
+}
+
 export interface PublicCatalogueUnitRow {
   collectionId: string;
   dateRaw: string;


### PR DESCRIPTION
The header scrubber and adjacent links ordered partial dates differently: a year-only photo put the same live letter at position 5 in the header and position 4 in the footer. Public chronological views now share one SQL ordering rule: unknown components sort at the beginning of the known range, followed by deterministic correspondence-unit identity ties.

The rule is used by list/summaries, collection detail, adjacent links, and chronological archive search. Other sort modes are unchanged.

Validation: all 116 backend test files / 1,210 tests passed; backend typecheck passed. A read-only PostgreSQL VALUES query confirmed the order of a year-only photo, same-day letters with different sequences, and an October letter. No application data or handwriting work was changed.
