### PR TITLE
Limit public image preloading to nearby content

### DIFF
--- a/docs/site-improvements/preload-measurements.json
+++ b/docs/site-improvements/preload-measurements.json
@@ -1,0 +1,16 @@
+[
+  {
+    "cohort": "1000 four-page letters",
+    "letters": 1000,
+    "pages": 4000,
+    "before_requests": 5000,
+    "after_requests": 6
+  },
+  {
+    "cohort": "Published collection 009",
+    "letters": 24,
+    "pages": 68,
+    "before_requests": 92,
+    "after_requests": 6
+  }
+]

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -129,7 +129,7 @@ export default function CollectionDetailPage() {
         if (cancelled) return;
         setCollection(data);
         setProfile(profileData);
-        // Start preloading carousel-width images for all letters in this collection
+        // Warm a small preview window without downloading the entire collection.
         if (data?.letters) {
           imagePreloadService.preloadCollection(data.letters);
         }
@@ -142,7 +142,7 @@ export default function CollectionDetailPage() {
     }
 
     fetchCollection();
-    return () => { cancelled = true; };
+    return () => { cancelled = true; imagePreloadService.cancelPending(); };
   }, [collectionCode]);
 
   /* ---- Header dock content ---- */

--- a/frontend/src/pages/LetterDetailPage.tsx
+++ b/frontend/src/pages/LetterDetailPage.tsx
@@ -237,6 +237,7 @@ export default function LetterDetailPage() {
   useEffect(() => {
     if (!letterId) return;
     imagePreloadService.focusLetter(letterId);
+    return () => imagePreloadService.cancelPending();
   }, [letterId]);
 
   // Keyboard nav

--- a/frontend/src/services/__tests__/imagePreloadService.test.ts
+++ b/frontend/src/services/__tests__/imagePreloadService.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImagePreloadService } from '../imagePreloadService';
+
+vi.mock('../../api/client', () => ({
+  getImageUrl: (url: string, options: { width: number }) => `${url}?width=${options.width}`,
+}));
+
+class TestImage {
+  static requests: TestImage[] = [];
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  naturalWidth = 800;
+  naturalHeight = 1200;
+  complete = false;
+  fetchPriority = '';
+  src = '';
+  removed = false;
+  constructor() { TestImage.requests.push(this); }
+  removeAttribute() { this.removed = true; }
+}
+
+function collection(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `letter-${index}`,
+    images: Array.from({ length: 4 }, (_, page) => ({ imageUrl: `/image-${index}-${page}` })),
+  }));
+}
+
+function finishAll() {
+  for (let i = 0; i < TestImage.requests.length; i++) TestImage.requests[i].onload?.();
+}
+
+describe('bounded image preloading', () => {
+  let service: ImagePreloadService;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestImage.requests = [];
+    vi.stubGlobal('Image', TestImage);
+    service = new ImagePreloadService();
+  });
+  afterEach(() => { service.clear(); vi.unstubAllGlobals(); vi.useRealTimers(); });
+
+  it('requests only six previews even for a thousand four-page letters', () => {
+    service.preloadCollection(collection(1000));
+    expect(TestImage.requests).toHaveLength(0);
+    vi.advanceTimersByTime(600);
+    expect(TestImage.requests).toHaveLength(4);
+    finishAll();
+    expect(TestImage.requests).toHaveLength(6);
+  });
+
+  it('cancels obsolete work and focuses only current pages and immediate neighbors', () => {
+    service.preloadCollection(collection(1000));
+    vi.advanceTimersByTime(600);
+    const obsolete = [...TestImage.requests];
+    const lateCallback = obsolete[0].onload!;
+    service.focusLetter('letter-500');
+    expect(obsolete.every((image) => image.removed)).toBe(true);
+    lateCallback();
+    finishAll();
+    const focused = TestImage.requests.slice(obsolete.length);
+    expect(focused).toHaveLength(10);
+    expect(focused.every((image) => /image-(499|500|501)-/.test(image.src))).toBe(true);
+    expect(service.isPreloaded(obsolete[0].src)).toBe(false);
+  });
+
+  it('does not mark failures as cached and permits a later retry', () => {
+    service.preloadCollection(collection(1));
+    vi.advanceTimersByTime(600);
+    const failed = TestImage.requests[0];
+    failed.onerror?.();
+    expect(service.isPreloaded(failed.src)).toBe(false);
+    service.focusLetter('letter-0');
+    finishAll();
+    expect(TestImage.requests.filter((image) => image.src === failed.src)).toHaveLength(2);
+    expect(service.getDimensions(failed.src)).toEqual({ width: 800, height: 1200 });
+  });
+
+  it('bounds cached metadata over a long navigation session', () => {
+    service.preloadCollection(collection(100));
+    for (let index = 0; index < 100; index++) {
+      service.focusLetter(`letter-${index}`);
+      finishAll();
+    }
+    expect(service.isPreloaded('/image-0-0?width=800')).toBe(false);
+    expect(service.isPreloaded('/image-99-0?width=800')).toBe(true);
+  });
+});

--- a/frontend/src/services/imagePreloadService.ts
+++ b/frontend/src/services/imagePreloadService.ts
@@ -1,226 +1,99 @@
 import { getImageUrl } from '../api/client';
 
-const CAROUSEL_WIDTH = 800;
-const THUMB_WIDTH = 32;
 const MAX_CONCURRENT = 4;
+const MAX_CACHED_URLS = 128;
+const MAX_PAGES_PER_LETTER = 3;
+type LetterImages = { id: string; images: { imageUrl: string }[] };
+type Dimensions = { width: number; height: number };
 
-type Priority = 'critical' | 'high' | 'normal' | 'low';
-const PRIORITY_ORDER: Record<Priority, number> = { critical: 0, high: 1, normal: 2, low: 3 };
-
-interface QueueEntry {
-  url: string;
-  priority: Priority;
-  letterId: string;
-}
-
-interface LetterImageInfo {
-  imageUrl: string;
-}
-
-const scheduleIdle: (cb: () => void) => number =
-  typeof requestIdleCallback === 'function'
-    ? requestIdleCallback
-    : (cb) => setTimeout(cb, 200) as unknown as number;
-
-class ImagePreloadService {
-  private preloaded = new Set<string>();
-  private dimensions = new Map<string, { width: number; height: number }>();
-  private queue: QueueEntry[] = [];
-  private active = 0;
+/** Speculative loading stays near the reader, never across an entire collection. */
+export class ImagePreloadService {
+  private loaded = new Map<string, Dimensions | null>();
+  private queue: string[] = [];
   private inflight = new Map<string, HTMLImageElement>();
-  private collectionLetterIds: string[] = [];
-  private currentLetterId: string | null = null;
-  private idleHandle: number | null = null;
+  private letters: LetterImages[] = [];
   private startupTimer: ReturnType<typeof setTimeout> | null = null;
 
-  /**
-   * Called from collection page after data loads.
-   * Enqueues first image of each letter at carousel width (high priority),
-   * then remaining images at low priority.
-   */
-  preloadCollection(letters: { id: string; images: LetterImageInfo[] }[]) {
-    this.collectionLetterIds = letters.map((l) => l.id);
-
-    // Phase 1: First image of each letter — enqueue but delay start
-    // so the collection page can finish rendering before we compete for network
-    for (const letter of letters) {
-      if (letter.images[0]) {
-        this.enqueue({
-          url: getImageUrl(letter.images[0].imageUrl, { width: CAROUSEL_WIDTH }),
-          priority: 'normal',
-          letterId: letter.id,
-        });
-        // Also preload the tiny thumb for instant blur-up
-        this.enqueue({
-          url: getImageUrl(letter.images[0].imageUrl, { width: THUMB_WIDTH }),
-          priority: 'high',
-          letterId: letter.id,
-        });
-      }
-    }
-
-    // Phase 2: Remaining images (deferred via idle callback)
-    this.idleHandle = scheduleIdle(() => {
-      for (const letter of letters) {
-        for (let i = 1; i < letter.images.length; i++) {
-          this.enqueue({
-            url: getImageUrl(letter.images[i].imageUrl, { width: CAROUSEL_WIDTH }),
-            priority: 'low',
-            letterId: letter.id,
-          });
-        }
-      }
-      this.processQueue();
-    });
-
-    // Delay the initial batch so the page renders smoothly first
-    if (this.startupTimer !== null) clearTimeout(this.startupTimer);
+  preloadCollection(letters: LetterImages[]) {
+    this.cancelPending();
+    this.letters = letters.map(({ id, images }) => ({
+      id, images: images.slice(0, MAX_PAGES_PER_LETTER),
+    }));
+    for (const letter of this.letters.slice(0, 3)) this.enqueueImages(letter, 1);
     this.startupTimer = setTimeout(() => {
       this.startupTimer = null;
       this.processQueue();
     }, 600);
   }
 
-  /**
-   * Called from letter detail page after letter data loads.
-   * Promotes current + adjacent letter images to critical/high priority.
-   */
   focusLetter(letterId: string) {
-    this.currentLetterId = letterId;
-
-    const idx = this.collectionLetterIds.indexOf(letterId);
-    if (idx === -1) return; // Not in a known collection
-
-    // Re-prioritize existing queue entries by proximity to current letter
-    for (const entry of this.queue) {
-      const entryIdx = this.collectionLetterIds.indexOf(entry.letterId);
-      if (entryIdx === -1) continue;
-
-      const distance = Math.abs(entryIdx - idx);
-      if (distance === 0) {
-        entry.priority = 'critical';
-      } else if (distance <= 2) {
-        entry.priority = 'high';
-      } else if (distance <= 5) {
-        entry.priority = 'normal';
-      }
-      // else stays at its current priority
+    this.cancelPending();
+    const index = this.letters.findIndex((letter) => letter.id === letterId);
+    if (index < 0) return;
+    this.enqueueImages(this.letters[index], MAX_PAGES_PER_LETTER);
+    for (const neighbor of [this.letters[index - 1], this.letters[index + 1]]) {
+      if (neighbor) this.enqueueImages(neighbor, 1);
     }
-
-    this.sortQueue();
     this.processQueue();
   }
 
-  /**
-   * Check if a URL has been preloaded (is in browser cache).
-   */
-  isPreloaded(url: string): boolean {
-    return this.preloaded.has(url);
-  }
+  isPreloaded(url: string): boolean { return this.loaded.has(url); }
+  getDimensions(url: string): Dimensions | null { return this.loaded.get(url) ?? null; }
 
-  /**
-   * Get stored dimensions for a preloaded image.
-   * Returns null if the image hasn't been preloaded or dimensions aren't available.
-   */
-  getDimensions(url: string): { width: number; height: number } | null {
-    return this.dimensions.get(url) ?? null;
-  }
-
-  /**
-   * Reset the service (e.g., when leaving a collection).
-   */
-  clear() {
-    // Cancel in-flight loads
+  /** Stop obsolete requests but keep the small navigation image index. */
+  cancelPending() {
+    if (this.startupTimer !== null) clearTimeout(this.startupTimer);
+    this.startupTimer = null;
+    this.queue = [];
     for (const img of this.inflight.values()) {
       img.onload = null;
       img.onerror = null;
+      img.removeAttribute('src');
     }
     this.inflight.clear();
-    this.queue = [];
-    this.active = 0;
-    this.collectionLetterIds = [];
-    this.currentLetterId = null;
-    if (this.idleHandle !== null) {
-      (typeof cancelIdleCallback === 'function' ? cancelIdleCallback : clearTimeout)(this.idleHandle);
-      this.idleHandle = null;
-    }
-    if (this.startupTimer !== null) {
-      clearTimeout(this.startupTimer);
-      this.startupTimer = null;
-    }
-    // Keep preloaded set and dimensions — those URLs are still in browser cache
   }
 
-  private enqueue(entry: QueueEntry) {
-    if (this.preloaded.has(entry.url)) return;
-    if (this.inflight.has(entry.url)) return;
-    // Check for duplicate in queue
-    const existing = this.queue.find((e) => e.url === entry.url);
-    if (existing) {
-      // Upgrade priority if needed
-      if (PRIORITY_ORDER[entry.priority] < PRIORITY_ORDER[existing.priority]) {
-        existing.priority = entry.priority;
-        this.sortQueue();
-      }
-      return;
-    }
-    this.queue.push(entry);
-    this.sortQueue();
+  clear() {
+    this.cancelPending();
+    this.letters = [];
+    this.loaded.clear();
   }
 
-  private sortQueue() {
-    const idx = this.currentLetterId
-      ? this.collectionLetterIds.indexOf(this.currentLetterId)
-      : -1;
-
-    this.queue.sort((a, b) => {
-      // Primary: priority level
-      const pDiff = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
-      if (pDiff !== 0) return pDiff;
-      // Secondary: proximity to current letter
-      if (idx !== -1) {
-        const distA = Math.abs(this.collectionLetterIds.indexOf(a.letterId) - idx);
-        const distB = Math.abs(this.collectionLetterIds.indexOf(b.letterId) - idx);
-        return distA - distB;
+  private enqueueImages(letter: LetterImages, limit: number) {
+    for (const image of letter.images.slice(0, limit)) {
+      for (const width of [800, 32]) {
+        const url = getImageUrl(image.imageUrl, { width });
+        if (!this.loaded.has(url) && !this.queue.includes(url)) this.queue.push(url);
       }
-      return 0;
-    });
+    }
   }
 
   private processQueue() {
-    while (this.active < MAX_CONCURRENT && this.queue.length > 0) {
-      const entry = this.queue.shift()!;
-      if (this.preloaded.has(entry.url) || this.inflight.has(entry.url)) continue;
-
-      this.active++;
+    while (this.inflight.size < MAX_CONCURRENT && this.queue.length > 0) {
+      const url = this.queue.shift()!;
+      if (this.loaded.has(url) || this.inflight.has(url)) continue;
       const img = new Image();
-      this.inflight.set(entry.url, img);
-
-      const done = () => {
-        this.active--;
-        this.preloaded.add(entry.url);
-        if (img.naturalWidth && img.naturalHeight) {
-          this.dimensions.set(entry.url, { width: img.naturalWidth, height: img.naturalHeight });
-        }
-        this.inflight.delete(entry.url);
-        this.processQueue();
-      };
-
-      img.onload = done;
-      img.onerror = () => {
-        this.active--;
-        this.preloaded.add(entry.url); // Mark as attempted to avoid retrying
-        this.inflight.delete(entry.url);
-        this.processQueue();
-      };
-      img.src = entry.url;
-
-      // Handle synchronously cached images
-      if (img.complete) {
+      this.inflight.set(url, img);
+      const done = (success: boolean) => {
+        // Ignore duplicate cached-image events and callbacks from cancelled work.
+        if (this.inflight.get(url) !== img) return;
         img.onload = null;
         img.onerror = null;
-        done();
-      }
+        this.inflight.delete(url);
+        if (success) {
+          this.loaded.set(url, img.naturalWidth && img.naturalHeight
+            ? { width: img.naturalWidth, height: img.naturalHeight } : null);
+          if (this.loaded.size > MAX_CACHED_URLS) {
+            this.loaded.delete(this.loaded.keys().next().value!);
+          }
+        }
+        this.processQueue();
+      };
+      img.onload = () => done(true);
+      img.onerror = () => done(false);
+      img.fetchPriority = 'low';
+      img.src = url;
+      if (img.complete) done(img.naturalWidth > 0);
     }
   }
 }


### PR DESCRIPTION
Collection pages queued every image in the collection. Speculative loading now warms three first-page previews, then follows only the current letter (up to three pages) and its immediate neighbors. Route changes cancel obsolete work, successful-image metadata is capped at 128 URLs, and failed requests remain retryable.

The bounded queue removes the old priority/sorting machinery. Visible image rendering is unchanged.

Measured by executing both scheduler versions against the same inputs with a completing image stub: published Collection 009 (24 letters, 68 pages) drops from 92 speculative requests to six; 1,000 four-page letters drop from 5,000 to six. These are scheduler counts, not full-page load times or transferred-byte measurements.

Validation: 157 frontend files / 1,103 tests passed, including concurrency/cancellation, late callbacks, failed-load retry, and cache bounds. Production build and the public archive-history browser check passed. Measurements are included in docs/site-improvements/preload-measurements.json.
