### PR TITLE
Preserve partial dates in collection ranges

### DIFF
--- a/backend/src/dto/__tests__/letter.dto.test.ts
+++ b/backend/src/dto/__tests__/letter.dto.test.ts
@@ -27,6 +27,11 @@ describe('letter DTO date formatting', () => {
     )).toBe('1947');
   });
 
+  it('normalizes lowercase unknown date digits', () => {
+    expect(formatLetterDate(letterDateInput(null, '1947xxxx'))).toBe('1947');
+    expect(formatLetterDate(letterDateInput(null, '194708xx'))).toBe('August 1947');
+  });
+
   it('falls back when a stored extracted date is not canonical ISO', () => {
     expect(formatLetterDate(
       letterDateInput('not-a-date', '18860315'),

--- a/backend/src/dto/letter.dto.ts
+++ b/backend/src/dto/letter.dto.ts
@@ -329,6 +329,7 @@ function getOrdinalSuffix(day: number): string {
  *   XXXXXXXX → "Unknown"
  */
 export function formatPartialDate(dateRaw: string): string {
+  dateRaw = dateRaw.toUpperCase();
   const yearPart = dateRaw.slice(0, 4);
   const monthPart = dateRaw.slice(4, 6);
   const dayPart = dateRaw.slice(6, 8);

--- a/backend/src/routes/collections.ts
+++ b/backend/src/routes/collections.ts
@@ -126,8 +126,8 @@ router.get('/collections', async (req, res, next) => {
       db
         .select({
           collectionId: letters.collectionId,
-          minDate: sql<string>`SUBSTRING(MIN(REPLACE(date_raw, 'X', '0') || date_raw) FILTER (WHERE date_raw ~ '^[0-9]{2}') FROM 9)`,
-          maxDate: sql<string>`SUBSTRING(MAX(REPLACE(date_raw, 'X', '9') || date_raw) FILTER (WHERE date_raw ~ '^[0-9]{2}') FROM 9)`,
+          minDate: sql<string>`SUBSTRING(MIN(REPLACE(UPPER(date_raw), 'X', '0') || UPPER(date_raw)) FILTER (WHERE date_raw ~ '^[0-9]{2}') FROM 9)`,
+          maxDate: sql<string>`SUBSTRING(MAX(REPLACE(UPPER(date_raw), 'X', '9') || UPPER(date_raw)) FILTER (WHERE date_raw ~ '^[0-9]{2}') FROM 9)`,
         })
         .from(letters)
         .where(and(

--- a/backend/src/routes/collections.ts
+++ b/backend/src/routes/collections.ts
@@ -119,12 +119,14 @@ router.get('/collections', async (req, res, next) => {
         ))
         .groupBy(letters.collectionId),
 
-      // Date ranges per collection
+      // Preserve filename date precision while comparing consistent eight-character keys.
+      // Prefixing the original value with its lower/upper bound lets MIN/MAX
+      // retain the winning partial date without sorting arrays for each collection.
       db
         .select({
           collectionId: letters.collectionId,
-          minDate: sql<string>`MIN(COALESCE(letter_date::text, date_raw))`,
-          maxDate: sql<string>`MAX(COALESCE(letter_date::text, date_raw))`,
+          minDate: sql<string>`SUBSTRING(MIN(REPLACE(date_raw, 'X', '0') || date_raw) FILTER (WHERE date_raw ~ '^[0-9]{2}') FROM 9)`,
+          maxDate: sql<string>`SUBSTRING(MAX(REPLACE(date_raw, 'X', '9') || date_raw) FILTER (WHERE date_raw ~ '^[0-9]{2}') FROM 9)`,
         })
         .from(letters)
         .where(and(

--- a/backend/src/services/__tests__/public-catalogue-unit.test.ts
+++ b/backend/src/services/__tests__/public-catalogue-unit.test.ts
@@ -21,7 +21,7 @@ describe('public catalogue units', () => {
         sql.raw('date_raw'), sql.raw('collection_id'), sql.raw('type_sequence'), descending,
       ));
       const direction = descending ? 'DESC' : 'ASC';
-      expect(query.sql).toBe(`REPLACE(date_raw, 'X', '0') ${direction}, date_raw ${direction}, collection_id ${direction}, type_sequence ${direction}`);
+      expect(query.sql).toBe(`REPLACE(UPPER(date_raw), 'X', '0') ${direction}, date_raw ${direction}, collection_id ${direction}, type_sequence ${direction}`);
     }
   });
 

--- a/backend/src/services/public-catalogue-unit.ts
+++ b/backend/src/services/public-catalogue-unit.ts
@@ -47,8 +47,8 @@ export function publicCatalogueChronologySql(
   descending = false,
 ) {
   return descending
-    ? sql`REPLACE(${dateRaw}, 'X', '0') DESC, ${dateRaw} DESC, ${collectionId} DESC, ${typeSequence} DESC`
-    : sql`REPLACE(${dateRaw}, 'X', '0') ASC, ${dateRaw} ASC, ${collectionId} ASC, ${typeSequence} ASC`;
+    ? sql`REPLACE(UPPER(${dateRaw}), 'X', '0') DESC, ${dateRaw} DESC, ${collectionId} DESC, ${typeSequence} DESC`
+    : sql`REPLACE(UPPER(${dateRaw}), 'X', '0') ASC, ${dateRaw} ASC, ${collectionId} ASC, ${typeSequence} ASC`;
 }
 
 export interface PublicCatalogueUnitRow {

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -7,24 +7,10 @@ import BackToTop from '../components/BackToTop';
 import { saveCollectionsSort, loadCollectionsSort } from '../utils/searchPersistence';
 import useIsMobile from '../hooks/useIsMobile';
 import './CollectionsPage.css';
+import { archiveDateSpan } from '../utils/archiveDateSpan';
 
 function formatDateRange(range: { min: string; max: string } | null | undefined): string | null {
-  if (!range) return null;
-  const fmt = (raw: string) => {
-    const digits = raw.replace(/[^0-9]/g, '').slice(0, 8);
-    if (digits.length < 6) return null;
-    const year = Number(digits.slice(0, 4));
-    const month = Number(digits.slice(4, 6)) - 1;
-    if (month < 0 || month > 11 || year < 1700) return null;
-    const hasDay = digits.length >= 8 && Number(digits.slice(6, 8)) > 0;
-    const d = new Date(year, month, hasDay ? Number(digits.slice(6, 8)) : 1);
-    return { year, month, label: d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }) };
-  };
-  const start = fmt(range.min);
-  const end = fmt(range.max);
-  if (!start) return null;
-  if (!end || (start.year === end.year && start.month === end.month)) return start.label;
-  return `${start.label} \u2014 ${end.label}`;
+  return range ? archiveDateSpan([range.min, range.max], false)?.label ?? null : null;
 }
 
 type SortField = 'number' | 'letters' | 'date' | 'title';

--- a/frontend/src/pages/collection-detail-utils.ts
+++ b/frontend/src/pages/collection-detail-utils.ts
@@ -1,3 +1,4 @@
+import { archiveDateSpan } from '../utils/archiveDateSpan';
 import type { CollectionProfileCorrespondent, KeyPerson } from "../api/collections";
 import type { LetterImageType, PublicLetter } from "../types/Letter";
 import { getMediaLabel, getPrimaryMediaType } from "../utils/letterPreview";
@@ -22,25 +23,6 @@ export interface CollectionStats {
   formatBreakdown: string;
 }
 
-function parseDateRaw(raw: string | undefined | null): Date | null {
-  if (!raw || raw.length < 8) return null;
-  const digits = raw.replace(/[^0-9]/g, "").slice(0, 8);
-  if (digits.length < 8) return null;
-  const year = Number(digits.slice(0, 4));
-  const month = Number(digits.slice(4, 6)) - 1;
-  const day = Number(digits.slice(6, 8));
-  if (month < 0 || month > 11 || day < 1 || day > 31) return null;
-  return new Date(year, month, day);
-}
-
-function formatDateShort(d: Date): string {
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
 function pluralize(count: number, singular: string, plural?: string): string {
   return count === 1 ? `${count} ${singular}` : `${count} ${plural || singular + "s"}`;
 }
@@ -62,25 +44,7 @@ const FORMAT_DISPLAY_ORDER: LetterImageType[] = [
 ];
 
 export function computeCollectionStats(letters: CollectionLetter[]): CollectionStats {
-  const dated = letters
-    .map((l) => ({ letter: l, date: parseDateRaw(l.metadata.dateRaw) }))
-    .filter((entry): entry is { letter: CollectionLetter; date: Date } => entry.date !== null)
-    .sort((a, b) => a.date.getTime() - b.date.getTime());
-
-  // Date span
-  let dateSpan: CollectionStats["dateSpan"] = null;
-  if (dated.length >= 2) {
-    const start = dated[0].date;
-    const end = dated[dated.length - 1].date;
-    dateSpan = {
-      start: formatDateShort(start),
-      end: formatDateShort(end),
-      label: `${formatDateShort(start)} \u2014 ${formatDateShort(end)}`,
-    };
-  } else if (dated.length === 1) {
-    const d = formatDateShort(dated[0].date);
-    dateSpan = { start: d, end: d, label: d };
-  }
+  const dateSpan = archiveDateSpan(letters.map((letter) => letter.metadata.dateRaw));
 
   // Format breakdown
   const formatCounts = new Map<LetterImageType, number>();

--- a/frontend/src/utils/__tests__/archiveDateSpan.test.ts
+++ b/frontend/src/utils/__tests__/archiveDateSpan.test.ts
@@ -9,6 +9,8 @@ describe('archiveDateSpan', () => {
     expect(archiveDateSpan(['19470810', '19471018', '1947XXXX'])?.label).toBe('1947');
   });
   it('preserves month and decade precision', () => {
+    expect(archiveDateSpan(['18XX0706'])?.label).toBe('Jul 6, 1800s');
+    expect(archiveDateSpan(['18XX0706'], false)?.label).toBe('Jul 1800s');
     expect(archiveDateSpan(['19X7XXXX'])?.label).toBe('1900s');
     expect(archiveDateSpan(['188XXXXX', '194708XX'])?.label).toBe('1880s — Aug 1947');
     expect(archiveDateSpan(['19470810'])?.label).toBe('Aug 10, 1947');

--- a/frontend/src/utils/__tests__/archiveDateSpan.test.ts
+++ b/frontend/src/utils/__tests__/archiveDateSpan.test.ts
@@ -9,6 +9,7 @@ describe('archiveDateSpan', () => {
     expect(archiveDateSpan(['19470810', '19471018', '1947XXXX'])?.label).toBe('1947');
   });
   it('preserves month and decade precision', () => {
+    expect(archiveDateSpan(['19X7XXXX'])?.label).toBe('1900s');
     expect(archiveDateSpan(['188XXXXX', '194708XX'])?.label).toBe('1880s — Aug 1947');
     expect(archiveDateSpan(['19470810'])?.label).toBe('Aug 10, 1947');
   });

--- a/frontend/src/utils/__tests__/archiveDateSpan.test.ts
+++ b/frontend/src/utils/__tests__/archiveDateSpan.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { archiveDateSpan } from '../archiveDateSpan';
+
+describe('archiveDateSpan', () => {
+  it('compares ISO and filename dates consistently', () => {
+    expect(archiveDateSpan(['1947-08-10', '19471018'], false)?.label).toBe('Aug 1947 — Oct 1947');
+  });
+  it('includes a year-only item without inventing a month or day', () => {
+    expect(archiveDateSpan(['19470810', '19471018', '1947XXXX'])?.label).toBe('1947');
+  });
+  it('preserves month and decade precision', () => {
+    expect(archiveDateSpan(['188XXXXX', '194708XX'])?.label).toBe('1880s — Aug 1947');
+    expect(archiveDateSpan(['19470810'])?.label).toBe('Aug 10, 1947');
+  });
+  it('does not invent a year for undated material', () => {
+    expect(archiveDateSpan(['XXXXXXXX', undefined, null])).toBeNull();
+  });
+});

--- a/frontend/src/utils/archiveDateSpan.ts
+++ b/frontend/src/utils/archiveDateSpan.ts
@@ -9,7 +9,10 @@ export function archiveDateSpan(values: (string | null | undefined)[], includeDa
     const month = Number(raw.slice(4, 6));
     const day = Number(raw.slice(6, 8));
     let label: string;
-    if (year.includes('X')) label = `${year.replace(/X/g, '0')}s`;
+    if (year.includes('X')) {
+      const knownPrefix = year.split('X')[0];
+      label = `${knownPrefix.padEnd(4, '0')}s`;
+    }
     else if (!month || month > 12) label = year;
     else label = `${MONTHS[month - 1]} ${includeDay && day >= 1 && day <= 31 ? `${day}, ` : ''}${year}`;
     return [{ lower: raw.replace(/X/g, '0'), upper: raw.replace(/X/g, '9'), label }];

--- a/frontend/src/utils/archiveDateSpan.ts
+++ b/frontend/src/utils/archiveDateSpan.ts
@@ -1,0 +1,21 @@
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** Filename dates retain X for unknown components; ISO dates are also accepted. */
+export function archiveDateSpan(values: (string | null | undefined)[], includeDay = true) {
+  const dates = values.flatMap((value) => {
+    const raw = value?.replace(/-/g, '').toUpperCase();
+    if (!raw || !/^\d{2}[\dX]{6}$/.test(raw)) return [];
+    const year = raw.slice(0, 4);
+    const month = Number(raw.slice(4, 6));
+    const day = Number(raw.slice(6, 8));
+    let label: string;
+    if (year.includes('X')) label = `${year.replace(/X/g, '0')}s`;
+    else if (!month || month > 12) label = year;
+    else label = `${MONTHS[month - 1]} ${includeDay && day >= 1 && day <= 31 ? `${day}, ` : ''}${year}`;
+    return [{ lower: raw.replace(/X/g, '0'), upper: raw.replace(/X/g, '9'), label }];
+  });
+  if (!dates.length) return null;
+  const first = dates.reduce((a, b) => a.lower <= b.lower ? a : b);
+  const last = dates.reduce((a, b) => a.upper >= b.upper ? a : b);
+  return { start: first.label, end: last.label, label: first.label === last.label ? first.label : `${first.label} — ${last.label}` };
+}

--- a/frontend/src/utils/archiveDateSpan.ts
+++ b/frontend/src/utils/archiveDateSpan.ts
@@ -8,13 +8,10 @@ export function archiveDateSpan(values: (string | null | undefined)[], includeDa
     const year = raw.slice(0, 4);
     const month = Number(raw.slice(4, 6));
     const day = Number(raw.slice(6, 8));
-    let label: string;
-    if (year.includes('X')) {
-      const knownPrefix = year.split('X')[0];
-      label = `${knownPrefix.padEnd(4, '0')}s`;
-    }
-    else if (!month || month > 12) label = year;
-    else label = `${MONTHS[month - 1]} ${includeDay && day >= 1 && day <= 31 ? `${day}, ` : ''}${year}`;
+    const yearLabel = year.includes('X') ? `${year.split('X')[0].padEnd(4, '0')}s` : year;
+    const label = !month || month > 12
+      ? yearLabel
+      : `${MONTHS[month - 1]} ${includeDay && day >= 1 && day <= 31 ? `${day}, ` : ''}${yearLabel}`;
     return [{ lower: raw.replace(/X/g, '0'), upper: raw.replace(/X/g, '9'), label }];
   });
   if (!dates.length) return null;


### PR DESCRIPTION
Collection ranges mixed ISO dates with filename dates and dropped partially known dates in the UI. Compare filename dates consistently in SQL while retaining their precision, and share date-span formatting between collection cards and details. Entirely unknown years do not replace known range endpoints.

Validation: 1,106 frontend tests pass, backend typecheck and frontend production build pass. Read-only PostgreSQL checks cover August–October exact dates, an encompassing year-only date, and an unknown date alongside exact dates. The aggregate retains constant-sized MIN/MAX values rather than collecting every date into arrays.
