### PR TITLE
Recover public navigation after catalogue request failures

### DIFF
--- a/frontend/src/components/LetterHeaderDock/__tests__/useCollectionLetters.test.tsx
+++ b/frontend/src/components/LetterHeaderDock/__tests__/useCollectionLetters.test.tsx
@@ -111,4 +111,22 @@ describe('useCollectionLetters', () => {
     } finally { now.mockRestore(); }
   });
 
+  it('refreshes a mounted collection after expiry without dropping its list', async () => {
+    vi.useFakeTimers();
+    try {
+      getArchiveShelfItemsMock.mockResolvedValueOnce(shelfResponse([shelfItem('old', 'mounted-expiry')]));
+      const { result, unmount } = renderHook(() => useCollectionLetters('mounted-expiry'));
+      await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+      expect(result.current?.[0].id).toBe('old');
+      const refresh = deferred<ArchiveShelfResponse>();
+      getArchiveShelfItemsMock.mockReturnValueOnce(refresh.promise);
+      await act(async () => { await vi.advanceTimersByTimeAsync(300_000); });
+      expect(result.current?.[0].id).toBe('old');
+      await act(async () => { refresh.resolve(shelfResponse([shelfItem('new', 'mounted-expiry')])); });
+      expect(result.current?.[0].id).toBe('new');
+      unmount();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally { vi.useRealTimers(); }
+  });
+
 });

--- a/frontend/src/components/LetterHeaderDock/__tests__/useCollectionLetters.test.tsx
+++ b/frontend/src/components/LetterHeaderDock/__tests__/useCollectionLetters.test.tsx
@@ -84,4 +84,31 @@ describe('useCollectionLetters', () => {
     });
     expect(result.current?.map((letter) => letter.id)).toEqual(['b-1']);
   });
+  it('handles a rejected request and retries on a later mount', async () => {
+    getArchiveShelfItemsMock.mockRejectedValueOnce(new Error('offline'));
+    const first = renderHook(() => useCollectionLetters('retry-collection'));
+    await act(async () => { await Promise.resolve(); });
+    expect(first.result.current).toBeNull();
+    first.unmount();
+    getArchiveShelfItemsMock.mockResolvedValueOnce(shelfResponse([shelfItem('recovered', 'retry-collection')]));
+    const second = renderHook(() => useCollectionLetters('retry-collection'));
+    await waitFor(() => expect(second.result.current?.[0].id).toBe('recovered'));
+    expect(getArchiveShelfItemsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes an expired collection on a later mount', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    try {
+      getArchiveShelfItemsMock.mockResolvedValue(shelfResponse([shelfItem('old', 'expires')]));
+      const first = renderHook(() => useCollectionLetters('expires'));
+      await waitFor(() => expect(first.result.current?.[0].id).toBe('old'));
+      first.unmount();
+      now.mockReturnValue(301_001);
+      getArchiveShelfItemsMock.mockResolvedValue(shelfResponse([shelfItem('new', 'expires')]));
+      const second = renderHook(() => useCollectionLetters('expires'));
+      await waitFor(() => expect(second.result.current?.[0].id).toBe('new'));
+      expect(getArchiveShelfItemsMock).toHaveBeenCalledTimes(2);
+    } finally { now.mockRestore(); }
+  });
+
 });

--- a/frontend/src/components/LetterHeaderDock/__tests__/useLetterScrubber.test.tsx
+++ b/frontend/src/components/LetterHeaderDock/__tests__/useLetterScrubber.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+import useLetterScrubber from '../useLetterScrubber';
+import type { AdjacentLettersResponse } from '../../../api/letters';
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }));
+vi.mock('../useCollectionLetters', () => ({ default: () => null }));
+
+it('uses adjacent navigation when the full collection is unavailable', () => {
+  const adjacent = { collectionCode: '009', total: 3, position: 2,
+    prev: { id: 'previous' }, next: { id: 'next' } } as AdjacentLettersResponse;
+  const { result } = renderHook(() => useLetterScrubber(adjacent, 'current'));
+  expect(result.current?.position).toBe(2);
+  result.current?.onPrev();
+  expect(navigate).toHaveBeenLastCalledWith('/letter/previous');
+  result.current?.onNext();
+  expect(navigate).toHaveBeenLastCalledWith('/letter/next');
+});

--- a/frontend/src/components/LetterHeaderDock/useCollectionLetters.ts
+++ b/frontend/src/components/LetterHeaderDock/useCollectionLetters.ts
@@ -73,19 +73,24 @@ export default function useCollectionLetters(collectionCode: string): ArchiveShe
 
   useEffect(() => {
     if (!collectionCode) return;
-    if (cachedItems(collectionCode)) return;
-
     let cancelled = false;
+    let refreshTimer: ReturnType<typeof setTimeout>;
 
-    fetchCollection(collectionCode)
-      .then((items) => {
-        if (!cancelled) {
-          setLoaded({ collectionCode, letters: items });
-        }
-      })
-      .catch(() => {});
-
-    return () => { cancelled = true; };
+    const refresh = () => {
+      fetchCollection(collectionCode)
+        .then((items) => {
+          if (!cancelled) setLoaded({ collectionCode, letters: items });
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (cancelled) return;
+          const expiresAt = cache.get(collectionCode)?.expiresAt ?? 0;
+          const delay = expiresAt > Date.now() ? expiresAt - Date.now() : CACHE_TTL_MS;
+          refreshTimer = setTimeout(refresh, delay);
+        });
+    };
+    refresh();
+    return () => { cancelled = true; clearTimeout(refreshTimer); };
   }, [collectionCode]);
 
   return letters;

--- a/frontend/src/components/LetterHeaderDock/useCollectionLetters.ts
+++ b/frontend/src/components/LetterHeaderDock/useCollectionLetters.ts
@@ -2,15 +2,22 @@ import { useState, useEffect } from "react";
 import { getArchiveShelfItems, type ArchiveShelfResponse } from "../../api/letters";
 import type { ArchiveShelfItem } from "../../types/Letter";
 
-/** Resolved results — persists for the session */
-const cache = new Map<string, ArchiveShelfItem[]>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHED_COLLECTIONS = 10;
+const cache = new Map<string, { items: ArchiveShelfItem[]; expiresAt: number }>();
+
+function cachedItems(code: string): ArchiveShelfItem[] | undefined {
+  const entry = cache.get(code);
+  return entry && entry.expiresAt > Date.now() ? entry.items : undefined;
+}
 
 /** In-flight promises — prevents duplicate concurrent fetches */
 const pending = new Map<string, Promise<ArchiveShelfItem[]>>();
 
 function fetchCollection(collectionCode: string): Promise<ArchiveShelfItem[]> {
   // Already resolved
-  if (cache.has(collectionCode)) return Promise.resolve(cache.get(collectionCode)!);
+  const cached = cachedItems(collectionCode);
+  if (cached) return Promise.resolve(cached);
 
   // Already in-flight — join existing request
   if (pending.has(collectionCode)) return pending.get(collectionCode)!;
@@ -33,12 +40,13 @@ function fetchCollection(collectionCode: string): Promise<ArchiveShelfItem[]> {
       page++;
     } while (page <= totalPages);
 
-    cache.set(collectionCode, items);
+    cache.delete(collectionCode);
+    cache.set(collectionCode, { items, expiresAt: Date.now() + CACHE_TTL_MS });
+    if (cache.size > MAX_CACHED_COLLECTIONS) cache.delete(cache.keys().next().value!);
     return items;
-  })();
+  })().finally(() => pending.delete(collectionCode));
 
   pending.set(collectionCode, promise);
-  promise.finally(() => pending.delete(collectionCode));
 
   return promise;
 }
@@ -55,7 +63,7 @@ export default function useCollectionLetters(collectionCode: string): ArchiveShe
     letters: ArchiveShelfItem[];
   } | null>(null);
   const letters = (
-    cache.get(collectionCode)
+    cachedItems(collectionCode)
     ?? (
       loaded?.collectionCode === collectionCode
         ? loaded.letters
@@ -65,7 +73,7 @@ export default function useCollectionLetters(collectionCode: string): ArchiveShe
 
   useEffect(() => {
     if (!collectionCode) return;
-    if (cache.has(collectionCode)) return;
+    if (cachedItems(collectionCode)) return;
 
     let cancelled = false;
 

--- a/frontend/src/components/LetterHeaderDock/useLetterScrubber.ts
+++ b/frontend/src/components/LetterHeaderDock/useLetterScrubber.ts
@@ -32,8 +32,8 @@ export default function useLetterScrubber(
   );
 
   const handlePrev = useCallback(() => {
-    if (!letters || total <= 1) return;
-    if (currentIdx >= 0) {
+    if (total <= 1) return;
+    if (letters && currentIdx >= 0) {
       const prevIdx = currentIdx === 0 ? letters.length - 1 : currentIdx - 1;
       navigate(`/letter/${letters[prevIdx].id}`);
     } else if (adjacent?.prev) {
@@ -42,8 +42,8 @@ export default function useLetterScrubber(
   }, [letters, currentIdx, total, adjacent?.prev, navigate]);
 
   const handleNext = useCallback(() => {
-    if (!letters || total <= 1) return;
-    if (currentIdx >= 0) {
+    if (total <= 1) return;
+    if (letters && currentIdx >= 0) {
       const nextIdx = currentIdx === letters.length - 1 ? 0 : currentIdx + 1;
       navigate(`/letter/${letters[nextIdx].id}`);
     } else if (adjacent?.next) {


### PR DESCRIPTION
Previous/next navigation now uses the adjacent-item response while the full catalogue is unavailable, so a failed background request does not disable working links. Return the promise produced by cleanup so rejected requests are handled, and refresh collection lists after five minutes with a ten-collection cache limit.

Validation: four focused hook tests pass, covering failed-request recovery, cache expiry, collection switching, and adjacent navigation fallback. Production build passes.
