### PR TITLE
Paginate catalogue units before loading public content

### DIFF
--- a/backend/src/routes/__tests__/letters.integration.test.ts
+++ b/backend/src/routes/__tests__/letters.integration.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { invokeRouter } from '../../test/express-test-utils.js';
 
 const {
+  cataloguePageMock,
   findCollectionsMock,
   findLettersMock,
   findFirstLetterMock,
@@ -23,6 +24,7 @@ const {
   sqlJoinMock,
   publicProjectionState,
 } = vi.hoisted(() => ({
+  cataloguePageMock: vi.fn(),
   findCollectionsMock: vi.fn(),
   findLettersMock: vi.fn(),
   findFirstLetterMock: vi.fn(),
@@ -44,6 +46,8 @@ const {
   sqlJoinMock: vi.fn(),
   publicProjectionState: { enabled: false },
 }));
+
+vi.mock('../../services/public-catalogue-page.js', () => ({ getPublicCataloguePage: cataloguePageMock }));
 
 vi.mock('drizzle-orm', () => ({
   eq: eqMock,
@@ -137,6 +141,7 @@ describe('letters route integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     publicProjectionState.enabled = false;
+    cataloguePageMock.mockResolvedValue({ total: 1, units: [{ collectionId: 'collection-9', dateRaw: '19470810', typeSequence: 1 }], where: { boundedPage: true } });
 
     eqMock.mockImplementation((left, right) => ({ op: 'eq', left, right }));
     andMock.mockImplementation((...conditions) => ({ op: 'and', conditions }));
@@ -175,6 +180,10 @@ describe('letters route integration', () => {
   });
 
   it('groups published letters by date and type sequence', async () => {
+    cataloguePageMock.mockResolvedValueOnce({ total: 2, units: [
+      { collectionId: 'collection-9', dateRaw: '19470810', typeSequence: 1 },
+      { collectionId: 'collection-9', dateRaw: '19470811', typeSequence: 1 },
+    ], where: { boundedPage: true } });
     findCollectionsMock.mockResolvedValueOnce([
       {
         id: 'collection-9',
@@ -241,6 +250,7 @@ describe('letters route integration', () => {
       total: 2,
     });
     expect(findCollectionsMock).toHaveBeenCalledTimes(1);
+    expect(findLettersMock.mock.calls[0][0].where).toEqual({ boundedPage: true });
     expect(transformLettersWithRelatedToDTOMock).toHaveBeenCalledWith([
       {
         letter: {
@@ -392,6 +402,13 @@ describe('letters route integration', () => {
       && values.includes('letters.metadataPublished')
       && values.includes('letters.sender')
     )).toBe(true);
+  });
+
+  it('keeps the total for an empty page and avoids fetching content', async () => {
+    cataloguePageMock.mockResolvedValueOnce({ total: 41, units: [], where: { boundedPage: true } });
+    const response = await invokeRouter(lettersRouter, { method: 'GET', url: '/letters/summaries', query: { page: '9' } });
+    expect(response.body).toEqual({ letters: [], total: 41, page: 9, limit: 20 });
+    expect(findLettersMock).not.toHaveBeenCalled();
   });
 
   it('returns lightweight shelf summaries for public archive browsing', async () => {

--- a/backend/src/routes/__tests__/letters.integration.test.ts
+++ b/backend/src/routes/__tests__/letters.integration.test.ts
@@ -404,6 +404,12 @@ describe('letters route integration', () => {
     )).toBe(true);
   });
 
+  it.each([{ page: '1.5' }, { limit: '2.5' }])('rejects fractional pagination before database selection: %j', async (query) => {
+    const response = await invokeRouter(lettersRouter, { method: 'GET', url: '/letters/summaries', query });
+    expect(response.statusCode).toBe(400);
+    expect(cataloguePageMock).not.toHaveBeenCalled();
+  });
+
   it('keeps the total for an empty page and avoids fetching content', async () => {
     cataloguePageMock.mockResolvedValueOnce({ total: 41, units: [], where: { boundedPage: true } });
     const response = await invokeRouter(lettersRouter, { method: 'GET', url: '/letters/summaries', query: { page: '9' } });

--- a/backend/src/routes/letters.ts
+++ b/backend/src/routes/letters.ts
@@ -1,3 +1,4 @@
+import { getPublicCataloguePage } from '../services/public-catalogue-page.js';
 import { Router } from 'express';
 import { eq, and, or, inArray, ilike, asc, desc, sql, type SQLWrapper } from 'drizzle-orm';
 import { db, letters, collections, letterPages, type LetterType } from '../db/index.js';
@@ -202,6 +203,7 @@ router.get('/letters', async (req, res, next) => {
     // For date sorting, use dateRaw with X replaced by 0
     // This makes unknown dates sort at the start of their range:
     // 18XXXXXX → 18000000, so "1800s" comes before "1801"
+    const cataloguePage = await getPublicCataloguePage(conditions, query);
     const sortFn = query.sortOrder === 'asc' ? asc : desc;
     const getSortExpression = () => {
       switch (query.sort) {
@@ -216,10 +218,9 @@ router.get('/letters', async (req, res, next) => {
       }
     };
 
-    // Fetch all letters (no workflow filter yet) - we need all types to determine primary
-    // Note: We fetch more than limit to account for filtering after grouping
-    const results = await db.query.letters.findMany({
-      where: and(...conditions),
+    // Load only this page of catalogue units, including their published companions.
+    const results = cataloguePage.units.length ? await db.query.letters.findMany({
+      where: cataloguePage.where,
       columns: {
         // Exclude large text/JSONB fields not needed for list view
         transcriptionText: false,
@@ -243,7 +244,7 @@ router.get('/letters', async (req, res, next) => {
         },
       },
       orderBy: [sortFn(getSortExpression())],
-    });
+    }) : [];
 
     // Group letters by (collectionId, dateRaw, typeSequence) — all types on the
     // same date merge into one group so covers/telegrams don't appear as separate entries
@@ -266,11 +267,11 @@ router.get('/letters', async (req, res, next) => {
       filteredResults.push(primary);
     }
 
-    // Apply pagination after filtering
-    const paginatedResults = filteredResults.slice(
-      (query.page - 1) * query.limit,
-      query.page * query.limit
-    );
+    const paginatedResults = cataloguePage.units.flatMap((unit) => {
+      const primary = filteredResults.find((letter) => letter.collectionId === unit.collectionId
+        && letter.dateRaw === unit.dateRaw && letter.typeSequence === unit.typeSequence);
+      return primary ? [primary] : [];
+    });
 
     // Enrich primary letters with related content from the already-loaded groupMap
     const enrichedResults = paginatedResults.map((letter) => {
@@ -291,7 +292,7 @@ router.get('/letters', async (req, res, next) => {
 
     const duration = Date.now() - start;
     req.log.info(
-      { resultCount: transformedLetters.length, totalGroups: filteredResults.length, page: query.page, duration },
+      { resultCount: transformedLetters.length, totalGroups: cataloguePage.total, page: query.page, duration },
       'Letters list completed'
     );
     logIfSlow(req.log, 'letters list query', duration, TIMING_THRESHOLDS.DB_QUERY);
@@ -300,7 +301,7 @@ router.get('/letters', async (req, res, next) => {
       letters: transformedLetters,
       page: query.page,
       limit: query.limit,
-      total: filteredResults.length,
+      total: cataloguePage.total,
     });
   } catch (error) {
     next(error);
@@ -326,6 +327,7 @@ router.get('/letters/summaries', async (req, res, next) => {
       }
     }
 
+    const cataloguePage = await getPublicCataloguePage(conditions, query);
     const sortFn = query.sortOrder === 'asc' ? asc : desc;
     const getSortExpression = () => {
       switch (query.sort) {
@@ -339,8 +341,8 @@ router.get('/letters/summaries', async (req, res, next) => {
       }
     };
 
-    const results = await db.query.letters.findMany({
-      where: and(...conditions),
+    const results = cataloguePage.units.length ? await db.query.letters.findMany({
+      where: cataloguePage.where,
       columns: {
         id: true,
         collectionId: true,
@@ -381,7 +383,7 @@ router.get('/letters/summaries', async (req, res, next) => {
         },
       },
       orderBy: [sortFn(getSortExpression())],
-    });
+    }) : [];
 
     // Group by (collectionId, dateRaw, typeSequence) — merge companion types
     // (e.g. L + C on same date) into one group, matching the adjacent API
@@ -403,10 +405,11 @@ router.get('/letters/summaries', async (req, res, next) => {
       filteredResults.push(primary);
     }
 
-    const paginatedResults = filteredResults.slice(
-      (query.page - 1) * query.limit,
-      query.page * query.limit,
-    );
+    const paginatedResults = cataloguePage.units.flatMap((unit) => {
+      const primary = filteredResults.find((letter) => letter.collectionId === unit.collectionId
+        && letter.dateRaw === unit.dateRaw && letter.typeSequence === unit.typeSequence);
+      return primary ? [primary] : [];
+    });
 
     const transformedLetters = paginatedResults.map((letter) => {
       const key = `${letter.collectionId}:${letter.dateRaw}:${letter.typeSequence}`;
@@ -416,7 +419,7 @@ router.get('/letters/summaries', async (req, res, next) => {
 
     const duration = Date.now() - start;
     req.log.info(
-      { resultCount: transformedLetters.length, totalGroups: filteredResults.length, page: query.page, duration },
+      { resultCount: transformedLetters.length, totalGroups: cataloguePage.total, page: query.page, duration },
       'Letters summary query completed',
     );
     logIfSlow(req.log, 'letters summary query', duration, TIMING_THRESHOLDS.DB_QUERY);
@@ -425,7 +428,7 @@ router.get('/letters/summaries', async (req, res, next) => {
       letters: transformedLetters,
       page: query.page,
       limit: query.limit,
-      total: filteredResults.length,
+      total: cataloguePage.total,
     });
   } catch (error) {
     next(error);

--- a/backend/src/schemas/letter.ts
+++ b/backend/src/schemas/letter.ts
@@ -30,6 +30,8 @@ export const publicLetterQuerySchema = letterQuerySchema
   .omit({ visibility: true, workflow: true, sort: true })
   .extend({
     visibility: z.literal('PUBLISHED').default('PUBLISHED'),
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(20),
     sort: z.enum(['createdAt', 'letterDate', 'sender']).default('createdAt'),
   })
   .strict();

--- a/backend/src/services/__tests__/public-catalogue-page.test.ts
+++ b/backend/src/services/__tests__/public-catalogue-page.test.ts
@@ -1,0 +1,38 @@
+import { expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { letters } from '../../db/index.js';
+import { cataloguePageSql, getPublicCataloguePage } from '../public-catalogue-page.js';
+import { publicLetterQuerySchema } from '../../schemas/letter.js';
+
+const { execute } = vi.hoisted(() => ({ execute: vi.fn() }));
+vi.mock('../../db/index.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../db/index.js')>(), db: { execute },
+}));
+const dialect = new PgDialect();
+const conditions = [eq(letters.visibility, 'PUBLISHED')];
+
+it('selects and counts published roots before bounded content hydration', () => {
+  const query = dialect.sqlToQuery(cataloguePageSql(conditions, publicLetterQuerySchema.parse({ page: 3, limit: 20, sort: 'sender' })));
+  expect(query.sql).toContain('DISTINCT ON (collection_id, date_raw, type_sequence)');
+  expect(query.sql).toContain('CASE WHEN metadata_published THEN sender ELSE NULL END');
+  expect(query.sql).toContain('COUNT(*)::int FROM roots');
+  expect(query.sql).toMatch(/LIMIT \$\d+ OFFSET \$\d+/);
+  expect(query.params).toContain('PUBLISHED');
+  expect(query.params.slice(-2)).toEqual([20, 40]);
+});
+
+it('constrains companion loading to the selected complete unit identity', async () => {
+  execute.mockResolvedValueOnce([{ total: 99, units: [{ collectionId: 'collection-a', dateRaw: '1947XXXX', typeSequence: 2 }] }]);
+  const page = await getPublicCataloguePage(conditions, publicLetterQuerySchema.parse({}));
+  expect(page.total).toBe(99);
+  expect(dialect.sqlToQuery(page.where!).params).toEqual(['PUBLISHED', 'collection-a', '1947XXXX', 2]);
+});
+
+it('retains the count and cannot load all rows for an empty page', async () => {
+  execute.mockResolvedValueOnce([{ total: 99, units: [] }]);
+  const page = await getPublicCataloguePage(conditions, publicLetterQuerySchema.parse({ page: 100 }));
+  expect(page.total).toBe(99);
+  expect(page.units).toEqual([]);
+  expect(dialect.sqlToQuery(page.where!).sql).toBe('FALSE');
+});

--- a/backend/src/services/public-catalogue-page.ts
+++ b/backend/src/services/public-catalogue-page.ts
@@ -1,0 +1,51 @@
+import { and, eq, or, sql, type SQL } from 'drizzle-orm';
+import { db, letters } from '../db/index.js';
+import type { PublicLetterQuery } from '../schemas/letter.js';
+import { publicCatalogueLetterTypeSql, publicCatalogueRepresentativeOrderSql } from './public-catalogue-unit.js';
+
+interface CatalogueUnit {
+  collectionId: string;
+  dateRaw: string;
+  typeSequence: number;
+}
+
+/** Select small unit keys before loading page images or text for the requested page. */
+export function cataloguePageSql(conditions: SQL[], query: PublicLetterQuery) {
+  const direction = query.sortOrder === 'asc' ? sql`ASC` : sql`DESC`;
+  const sort = query.sort === 'sender' ? sql`sender` : query.sort === 'createdAt'
+    ? sql`created_at` : sql`REPLACE(date_raw, 'X', '0')`;
+  return sql`
+    WITH roots AS (
+      SELECT DISTINCT ON (collection_id, date_raw, type_sequence)
+        collection_id, date_raw, type_sequence, created_at,
+        CASE WHEN metadata_published THEN sender ELSE NULL END AS sender
+      FROM ${letters}
+      WHERE ${and(...conditions, publicCatalogueLetterTypeSql(letters.type))}
+      ORDER BY collection_id, date_raw, type_sequence,
+        ${publicCatalogueRepresentativeOrderSql(letters.type)}, ${letters.id}
+    ), page AS (
+      SELECT collection_id AS "collectionId", date_raw AS "dateRaw", type_sequence AS "typeSequence",
+        ROW_NUMBER() OVER (ORDER BY ${sort} ${direction}, date_raw ${direction}, collection_id ${direction}, type_sequence ${direction}) AS position
+      FROM roots
+      ORDER BY ${sort} ${direction}, date_raw ${direction}, collection_id ${direction}, type_sequence ${direction}
+      LIMIT ${query.limit} OFFSET ${(query.page - 1) * query.limit}
+    )
+    SELECT (SELECT COUNT(*)::int FROM roots) AS total,
+      COALESCE(json_agg(page ORDER BY position), '[]'::json) AS units FROM page
+  `;
+}
+
+export async function getPublicCataloguePage(conditions: SQL[], query: PublicLetterQuery) {
+  const result = await db.execute(cataloguePageSql(conditions, query));
+  const row = (result as unknown as Array<{ total: number; units: CatalogueUnit[] }>)[0];
+  const units = row?.units ?? [];
+  return {
+    total: Number(row?.total ?? 0),
+    units,
+    where: units.length ? and(...conditions, or(...units.map((unit) => and(
+      eq(letters.collectionId, unit.collectionId),
+      eq(letters.dateRaw, unit.dateRaw),
+      eq(letters.typeSequence, unit.typeSequence),
+    )))) : sql`FALSE`,
+  };
+}


### PR DESCRIPTION
Public list and summary requests loaded every matching row, text field, and page before applying pagination. Select and count published catalogue roots in SQL first, then load only the requested units and their published companions. Sorting is deterministic and uses the selected root for sender/creation order; metadata publication remains enforced.

Validation: 1,215 backend tests and typecheck pass. Read-only PostgreSQL checks on the local 95-unit catalogue returned 20 units on each of the first two pages with no overlap; an out-of-range page returned zero units and retained total=95. Warm key-selection queries took approximately 2 ms locally; this is not a production latency claim. Route regressions cover bounded companion loading and empty-page totals.
