### PR TITLE
Use native links for public archive cards

### DIFF
--- a/e2e/tests/public-archive-history.mocked.spec.ts
+++ b/e2e/tests/public-archive-history.mocked.spec.ts
@@ -73,6 +73,22 @@ function waitForArchiveSearch(
 }
 
 test.describe('@mocked Public archive history', () => {
+  test('opens an archive card in a new tab using its native destination', async ({ page, context }) => {
+    await installMockPublicHomeApi(page);
+    await page.route((url) => isApiPath(url, '/letters/search'), async (route) => {
+      await route.fulfill({ json: { letters: [{ id: 'native-link-letter', title: 'A family letter', imageType: 'letter', verified: true }], page: 1, limit: 24, total: 1, facets: EMPTY_FACETS } });
+    });
+    await page.goto('/');
+    const link = page.locator('a.letter-card');
+    await expect(link).toHaveAttribute('href', '/letter/native-link-letter');
+    const opened = context.waitForEvent('page');
+    await link.click({ button: 'middle' });
+    const tab = await opened;
+    await tab.waitForURL('**/letter/native-link-letter');
+    await expect(page).toHaveURL(/\/$/);
+    await tab.close();
+  });
+
   test('keeps Home URL, input, and requests synchronized through Back and Forward', async ({
     page,
   }) => {

--- a/frontend/src/components/ArchiveList/ArchiveList.css
+++ b/frontend/src/components/ArchiveList/ArchiveList.css
@@ -543,3 +543,8 @@
     -webkit-line-clamp: 2;
   }
 }
+
+/* Public links retain Safari's copy/open link menu; picker buttons keep their touch behavior. */
+a.letter-card {
+  -webkit-touch-callout: default;
+}

--- a/frontend/src/components/InfiniteCarousel.tsx
+++ b/frontend/src/components/InfiniteCarousel.tsx
@@ -179,7 +179,8 @@ export default function InfiniteCarousel({
   const mouseDownRef = useRef(false);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    if ((e.target as HTMLElement).closest('a, button')) return;
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if ((e.target as HTMLElement).closest('button, a:not([data-carousel-drag])')) return;
     mouseDownRef.current = true;
     startDrag(e.clientX, e.clientY);
   }, [startDrag]);

--- a/frontend/src/components/InfiniteCarousel.tsx
+++ b/frontend/src/components/InfiniteCarousel.tsx
@@ -202,7 +202,6 @@ export default function InfiniteCarousel({
     if (!mouseDownRef.current) return;
     mouseDownRef.current = false;
     endDrag();
-    draggedRef.current = false;
   }, [endDrag]);
 
   const handleClickCapture = useCallback((e: React.MouseEvent) => {

--- a/frontend/src/components/InfiniteCarousel.tsx
+++ b/frontend/src/components/InfiniteCarousel.tsx
@@ -179,6 +179,8 @@ export default function InfiniteCarousel({
   const mouseDownRef = useRef(false);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // A new gesture must never inherit click suppression from an earlier drag.
+    draggedRef.current = false;
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     if ((e.target as HTMLElement).closest('button, a:not([data-carousel-drag])')) return;
     mouseDownRef.current = true;
@@ -200,9 +202,14 @@ export default function InfiniteCarousel({
     if (!mouseDownRef.current) return;
     mouseDownRef.current = false;
     endDrag();
+    draggedRef.current = false;
   }, [endDrag]);
 
   const handleClickCapture = useCallback((e: React.MouseEvent) => {
+    if (e.detail === 0) {
+      draggedRef.current = false;
+      return;
+    }
     if (suppressClickAfterDrag && draggedRef.current) {
       e.stopPropagation();
       e.preventDefault();

--- a/frontend/src/components/LetterCard/LetterCard.tsx
+++ b/frontend/src/components/LetterCard/LetterCard.tsx
@@ -263,7 +263,7 @@ function LetterCard({
     showPreviewForABeat();
   };
 
-  const handleCardTouchStart = (_event: TouchEvent<HTMLButtonElement>) => {
+  const handleCardTouchStart = (_event: TouchEvent<HTMLAnchorElement>) => {
     if (!hasSearchPreview) return;
     if (!isTouchDevice) return;
     touchPreviewRetouchRef.current = previewVisible;
@@ -275,7 +275,7 @@ function LetterCard({
     setPreviewVisible(true);
   };
 
-  const handleCardTouchMove = (event: TouchEvent<HTMLButtonElement>) => {
+  const handleCardTouchMove = (event: TouchEvent<HTMLAnchorElement>) => {
     if (!isTouchDevice || !touchPreviewActiveRef.current) return;
 
     const touch = event.touches[0];
@@ -294,7 +294,7 @@ function LetterCard({
     }
   };
 
-  const handleCardTouchEnd = (_event: TouchEvent<HTMLButtonElement>) => {
+  const handleCardTouchEnd = (_event: TouchEvent<HTMLAnchorElement>) => {
     if (!isTouchDevice) return;
     const startedAt = touchPreviewStartedAtRef.current;
     if (
@@ -323,18 +323,21 @@ function LetterCard({
       onMouseEnter={handleCardMouseEnter}
       onMouseLeave={handleCardMouseLeave}
     >
-      <button
-        type="button"
+      <a
+        href={`/letter/${card.id}`}
         className={`letter-card letter-card--${card.imageType}${hasSearchPreview ? " letter-card--has-search-match" : ""}${previewVisible ? " letter-card--search-preview-visible" : ""}`}
         onTouchStart={handleCardTouchStart}
         onTouchMove={handleCardTouchMove}
         onTouchEnd={handleCardTouchEnd}
         onTouchCancel={handleCardTouchEnd}
-        onClick={() => {
+        onClick={(event) => {
           if (swallowNextClickRef.current) {
             swallowNextClickRef.current = false;
+            event.preventDefault();
             return;
           }
+          if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+          event.preventDefault();
           onClick(card.id);
         }}
         aria-label={ariaLabel || `${mediaLabel}: ${card.title || "Unknown item"}`}
@@ -391,7 +394,7 @@ function LetterCard({
             </p>
           )}
         </div>
-      </button>
+      </a>
       {hasSearchPreview && !isTouchDevice && (
         <button
           type="button"

--- a/frontend/src/components/LetterCard/LetterCard.tsx
+++ b/frontend/src/components/LetterCard/LetterCard.tsx
@@ -11,6 +11,7 @@ import { getAppScrollRootForIO } from "../../utils/appScroll";
 interface LetterCardProps {
   card: LetterCardData;
   onClick: (id: string) => void;
+  selection?: boolean;
   sortCue?: {
     label: string;
     value: string;
@@ -138,6 +139,7 @@ function renderHighlightedExcerpt(
 function LetterCard({
   card,
   onClick,
+  selection = false,
   sortCue = null,
 }: LetterCardProps) {
   const shellRef = useRef<HTMLDivElement | null>(null);
@@ -263,7 +265,7 @@ function LetterCard({
     showPreviewForABeat();
   };
 
-  const handleCardTouchStart = (_event: TouchEvent<HTMLAnchorElement>) => {
+  const handleCardTouchStart = (_event: TouchEvent<HTMLAnchorElement | HTMLButtonElement>) => {
     if (!hasSearchPreview) return;
     if (!isTouchDevice) return;
     touchPreviewRetouchRef.current = previewVisible;
@@ -275,7 +277,7 @@ function LetterCard({
     setPreviewVisible(true);
   };
 
-  const handleCardTouchMove = (event: TouchEvent<HTMLAnchorElement>) => {
+  const handleCardTouchMove = (event: TouchEvent<HTMLAnchorElement | HTMLButtonElement>) => {
     if (!isTouchDevice || !touchPreviewActiveRef.current) return;
 
     const touch = event.touches[0];
@@ -294,7 +296,7 @@ function LetterCard({
     }
   };
 
-  const handleCardTouchEnd = (_event: TouchEvent<HTMLAnchorElement>) => {
+  const handleCardTouchEnd = (_event: TouchEvent<HTMLAnchorElement | HTMLButtonElement>) => {
     if (!isTouchDevice) return;
     const startedAt = touchPreviewStartedAtRef.current;
     if (
@@ -314,6 +316,7 @@ function LetterCard({
     }, TOUCH_PREVIEW_RELEASE_HIDE_MS);
   };
 
+  const CardControl = selection ? 'button' : 'a';
   const visibleSearchPreview = previewVisible && hasSearchPreview && searchPreview;
 
   return (
@@ -323,8 +326,9 @@ function LetterCard({
       onMouseEnter={handleCardMouseEnter}
       onMouseLeave={handleCardMouseLeave}
     >
-      <a
-        href={`/letter/${card.id}`}
+      <CardControl
+        type={selection ? "button" : undefined}
+        href={selection ? undefined : `/letter/${card.id}`}
         className={`letter-card letter-card--${card.imageType}${hasSearchPreview ? " letter-card--has-search-match" : ""}${previewVisible ? " letter-card--search-preview-visible" : ""}`}
         onTouchStart={handleCardTouchStart}
         onTouchMove={handleCardTouchMove}
@@ -336,7 +340,7 @@ function LetterCard({
             event.preventDefault();
             return;
           }
-          if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+          if (!selection && (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)) return;
           event.preventDefault();
           onClick(card.id);
         }}
@@ -394,7 +398,7 @@ function LetterCard({
             </p>
           )}
         </div>
-      </a>
+      </CardControl>
       {hasSearchPreview && !isTouchDevice && (
         <button
           type="button"

--- a/frontend/src/components/LetterCard/__tests__/LetterCard.test.tsx
+++ b/frontend/src/components/LetterCard/__tests__/LetterCard.test.tsx
@@ -65,13 +65,14 @@ describe("LetterCard", () => {
       />,
     );
 
-    const button = screen.getByRole("button", {
+    const button = screen.getByRole("link", {
       name: /Jimmie → Molly/i,
     });
     const previewToggle = screen.getByRole("button", {
       name: "Show search match preview",
     });
 
+    expect(button).toHaveAttribute("href", "/letter/letter-1");
     expect(button).not.toHaveAttribute("title");
     expect(screen.queryByText("3 matches")).not.toBeInTheDocument();
     expect(screen.queryByText("Transcript match")).not.toBeInTheDocument();
@@ -143,7 +144,7 @@ describe("LetterCard", () => {
       />,
     );
 
-    const button = screen.getByRole("button", {
+    const button = screen.getByRole("link", {
       name: /August 11th, 1947/i,
     });
     const shell = button.closest(".letter-card-shell") as HTMLElement;
@@ -223,7 +224,7 @@ describe("LetterCard", () => {
       />,
     );
 
-    const button = screen.getByRole("button", {
+    const button = screen.getByRole("link", {
       name: /August 13th, 1947/i,
     });
     const shell = button.closest(".letter-card-shell") as HTMLElement;

--- a/frontend/src/components/LetterCard/__tests__/LetterCard.test.tsx
+++ b/frontend/src/components/LetterCard/__tests__/LetterCard.test.tsx
@@ -28,6 +28,16 @@ afterEach(() => {
 });
 
 describe("LetterCard", () => {
+  it("keeps admin picker cards as buttons even with modified clicks", () => {
+    const onClick = vi.fn();
+    render(<LetterCard selection card={{ id: "pick-1", imageType: "letter", title: "Pick me" }} onClick={onClick} />);
+    const button = screen.getByRole("button", { name: "Letter" });
+    expect(button).not.toHaveAttribute("href");
+    fireEvent.click(button, { ctrlKey: true });
+    expect(onClick).toHaveBeenCalledWith("pick-1");
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
   it("only cools down a card after the auto-preview fully finishes", async () => {
     vi.useFakeTimers();
     const onClick = vi.fn();

--- a/frontend/src/components/ShowcaseCard.css
+++ b/frontend/src/components/ShowcaseCard.css
@@ -237,6 +237,7 @@
 }
 
 .cd-highlight-open-link {
+  text-decoration: none;
   position: absolute;
   inset: 0;
   color: inherit;

--- a/frontend/src/components/ShowcaseCard.css
+++ b/frontend/src/components/ShowcaseCard.css
@@ -235,3 +235,27 @@
     opacity: 1;
   }
 }
+
+.cd-highlight-open-link {
+  position: absolute;
+  inset: 0;
+  color: inherit;
+  border-radius: inherit;
+  -webkit-touch-callout: default;
+}
+
+.cd-highlight-open-link:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: -4px;
+}
+
+.cd-highlight-zone {
+  border: 0;
+  color: inherit;
+}
+
+.cd-highlight-zone:focus-visible {
+  opacity: 1;
+  outline: 3px solid currentColor;
+  outline-offset: -4px;
+}

--- a/frontend/src/components/ShowcaseCard.tsx
+++ b/frontend/src/components/ShowcaseCard.tsx
@@ -17,7 +17,7 @@ export interface ShowcaseItem {
 
 interface ShowcaseCardProps {
   items: ShowcaseItem[];
-  onNavigate: (letterId: string, imageId?: string) => void;
+  onNavigate?: (letterId: string, imageId?: string) => void;
   onInteraction?: () => void;
 }
 
@@ -40,16 +40,17 @@ export default function ShowcaseCard({ items, onNavigate, onInteraction }: Showc
     onInteraction?.();
   };
 
+  const Content = onNavigate ? 'a' : 'div';
   const params = new URLSearchParams({ from: 'highlight' });
   if (item.imageId) params.set('image', item.imageId);
 
   return (
     <div className={`cd-highlight-card cd-highlight-card--${item.mediaType}`}>
-      <a className="cd-highlight-open-link" data-carousel-drag draggable={false}
-        href={`/letter/${item.letterId}?${params.toString()}`}
+      <Content className="cd-highlight-open-link" data-carousel-drag={onNavigate ? true : undefined} draggable={false}
+        href={onNavigate ? `/letter/${item.letterId}?${params.toString()}` : undefined}
         aria-label={[item.label, item.peopleLine, item.date, item.hook].filter(Boolean).join(', ')}
-        onClick={(event) => {
-          if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        onClick={(event: ReactMouseEvent) => {
+          if (!onNavigate || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
           event.preventDefault();
           onNavigate(item.letterId, item.imageId);
         }}
@@ -87,7 +88,7 @@ export default function ShowcaseCard({ items, onNavigate, onInteraction }: Showc
           <p className="cd-highlight-hook">{item.hook}</p>
         )}
       </div>
-      </a>
+      </Content>
       {hasMultiple && (
         <>
           <span className="cd-highlight-page-counter">

--- a/frontend/src/components/ShowcaseCard.tsx
+++ b/frontend/src/components/ShowcaseCard.tsx
@@ -40,12 +40,20 @@ export default function ShowcaseCard({ items, onNavigate, onInteraction }: Showc
     onInteraction?.();
   };
 
+  const params = new URLSearchParams({ from: 'highlight' });
+  if (item.imageId) params.set('image', item.imageId);
+
   return (
-    <button
-      type="button"
-      className={`cd-highlight-card cd-highlight-card--${item.mediaType}`}
-      onClick={() => onNavigate(item.letterId, item.imageId)}
-    >
+    <div className={`cd-highlight-card cd-highlight-card--${item.mediaType}`}>
+      <a className="cd-highlight-open-link" data-carousel-drag draggable={false}
+        href={`/letter/${item.letterId}?${params.toString()}`}
+        aria-label={[item.label, item.peopleLine, item.date, item.hook].filter(Boolean).join(', ')}
+        onClick={(event) => {
+          if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+          event.preventDefault();
+          onNavigate(item.letterId, item.imageId);
+        }}
+      >
       {items.map((gi, idx) => (
         idx === index && gi.imageUrl ? (
           <ProgressiveImage
@@ -79,23 +87,24 @@ export default function ShowcaseCard({ items, onNavigate, onInteraction }: Showc
           <p className="cd-highlight-hook">{item.hook}</p>
         )}
       </div>
+      </a>
       {hasMultiple && (
         <>
           <span className="cd-highlight-page-counter">
             {index + 1}/{items.length}
           </span>
-          <div
+          <button type="button"
             className="cd-highlight-zone cd-highlight-zone--prev"
             onClick={handlePrev}
             aria-label="Previous"
           />
-          <div
+          <button type="button"
             className="cd-highlight-zone cd-highlight-zone--next"
             onClick={handleNext}
             aria-label="Next"
           />
         </>
       )}
-    </button>
+    </div>
   );
 }

--- a/frontend/src/components/__tests__/InfiniteCarousel.test.tsx
+++ b/frontend/src/components/__tests__/InfiniteCarousel.test.tsx
@@ -76,6 +76,27 @@ describe("InfiniteCarousel", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses the same drag click after leaving and re-entering the track", () => {
+    const onClick = vi.fn((event) => event.preventDefault());
+    const { container } = render(<InfiniteCarousel suppressClickAfterDrag>{[
+      <a key="a" href="/letter/one" data-carousel-drag onClick={onClick}>Open scan</a>,
+      <div key="b">Other slide</div>,
+    ]}</InfiniteCarousel>);
+    const link = screen.getAllByText('Open scan')[0];
+    const track = container.querySelector('.carousel-track')!;
+    fireEvent.mouseDown(link, { button: 0, clientX: 300, clientY: 100 });
+    fireEvent.mouseMove(link, { clientX: 100, clientY: 100 });
+    fireEvent.mouseLeave(track);
+    fireEvent.mouseEnter(track);
+    fireEvent.mouseUp(link);
+    fireEvent.click(link, { detail: 1 });
+    expect(onClick).not.toHaveBeenCalled();
+    fireEvent.mouseDown(link, { button: 0 });
+    fireEvent.mouseUp(link);
+    fireEvent.click(link, { detail: 1 });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it("renders children as slides", () => {
     const { container } = render(
       <InfiniteCarousel>

--- a/frontend/src/components/__tests__/InfiniteCarousel.test.tsx
+++ b/frontend/src/components/__tests__/InfiniteCarousel.test.tsx
@@ -38,10 +38,41 @@ describe("InfiniteCarousel", () => {
     fireEvent.mouseDown(link, { button: 0, clientX: 300, clientY: 100 });
     fireEvent.mouseMove(link, { clientX: 100, clientY: 100 });
     fireEvent.mouseUp(link);
-    fireEvent.click(link);
+    fireEvent.click(link, { detail: 1 });
     expect(onClick).not.toHaveBeenCalled();
     expect(container.querySelectorAll('[role="tab"]')[1]).toHaveAttribute('aria-selected', 'true');
-    fireEvent.click(link);
+    fireEvent.click(link, { detail: 1 });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not swallow a CTA click after a drag leaves the track", () => {
+    const onClick = vi.fn((event) => event.preventDefault());
+    const { container } = render(<InfiniteCarousel suppressClickAfterDrag>{[
+      <div key="a">Drag surface</div>,
+      <a key="b" href="/collections" onClick={onClick}>Browse collections</a>,
+    ]}</InfiniteCarousel>);
+    const track = container.querySelector('.carousel-track')!;
+    fireEvent.mouseDown(track, { button: 0, clientX: 300, clientY: 100 });
+    fireEvent.mouseMove(track, { clientX: 100, clientY: 100 });
+    fireEvent.mouseLeave(track);
+    const link = screen.getAllByText('Browse collections')[0];
+    fireEvent.mouseDown(link, { button: 0 });
+    fireEvent.mouseUp(link);
+    fireEvent.click(link, { detail: 1 });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply pointer drag suppression to keyboard activation", () => {
+    const onClick = vi.fn((event) => event.preventDefault());
+    const { container } = render(<InfiniteCarousel suppressClickAfterDrag>{[
+      <div key="a">Drag surface</div>,
+      <a key="b" href="/collections" onClick={onClick}>Browse collections</a>,
+    ]}</InfiniteCarousel>);
+    const track = container.querySelector('.carousel-track')!;
+    fireEvent.mouseDown(track, { button: 0, clientX: 300, clientY: 100 });
+    fireEvent.mouseMove(track, { clientX: 100, clientY: 100 });
+    fireEvent.mouseUp(track);
+    fireEvent.click(screen.getAllByText('Browse collections')[0], { detail: 0 });
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/components/__tests__/InfiniteCarousel.test.tsx
+++ b/frontend/src/components/__tests__/InfiniteCarousel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import InfiniteCarousel from "../InfiniteCarousel";
 
@@ -26,6 +26,23 @@ describe("InfiniteCarousel", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("allows opted-in links to drag without navigating, while ordinary clicks still work", () => {
+    const onClick = vi.fn((event) => event.preventDefault());
+    const { container } = render(<InfiniteCarousel suppressClickAfterDrag>{[
+      <a key="a" href="/letter/one" data-carousel-drag draggable={false} onClick={onClick}>Open scan</a>,
+      <div key="b">Other slide</div>,
+    ]}</InfiniteCarousel>);
+    const link = screen.getAllByText("Open scan")[0];
+    fireEvent.mouseDown(link, { button: 0, clientX: 300, clientY: 100 });
+    fireEvent.mouseMove(link, { clientX: 100, clientY: 100 });
+    fireEvent.mouseUp(link);
+    fireEvent.click(link);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('[role="tab"]')[1]).toHaveAttribute('aria-selected', 'true');
+    fireEvent.click(link);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it("renders children as slides", () => {

--- a/frontend/src/components/__tests__/ShowcaseCard.test.tsx
+++ b/frontend/src/components/__tests__/ShowcaseCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import ShowcaseCard, { type ShowcaseItem } from '../ShowcaseCard';
 
@@ -21,10 +22,37 @@ describe('ShowcaseCard image loading', () => {
     fireEvent.click(screen.getByLabelText('Next'));
     expect(screen.getAllByRole('img')).toHaveLength(1);
     expect(screen.getByRole('img')).toHaveAttribute('src', '/image-1.jpg');
-    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/letter/letter-1?from=highlight&image=image-1');
+    fireEvent.click(screen.getByRole('link'));
     expect(onNavigate).toHaveBeenCalledWith('letter-1', 'image-1');
     fireEvent.click(screen.getByLabelText('Previous'));
     fireEvent.click(screen.getByLabelText('Previous'));
     expect(screen.getByRole('img')).toHaveAttribute('src', '/image-99.jpg');
   });
+  it('keeps modified clicks native and page controls separate from navigation', () => {
+    const onNavigate = vi.fn();
+    render(<ShowcaseCard items={items} onNavigate={onNavigate} />);
+    document.addEventListener('click', (event) => {
+      expect(event.defaultPrevented).toBe(false);
+      event.preventDefault(); // jsdom cannot perform the browser's native navigation.
+    }, { once: true });
+    fireEvent.click(screen.getByRole('link'), { ctrlKey: true });
+    expect(onNavigate).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(screen.getByRole('link')).not.toContainElement(screen.getByRole('button', { name: 'Next' }));
+  });
+
+  it('lets the keyboard change scans and open the selected destination', async () => {
+    const onNavigate = vi.fn();
+    const user = userEvent.setup();
+    render(<ShowcaseCard items={items} onNavigate={onNavigate} />);
+    screen.getByRole('button', { name: 'Next' }).focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/image-1.jpg');
+    screen.getByRole('link').focus();
+    await user.keyboard('{Enter}');
+    expect(onNavigate).toHaveBeenCalledWith('letter-1', 'image-1');
+  });
+
 });

--- a/frontend/src/components/__tests__/ShowcaseCard.test.tsx
+++ b/frontend/src/components/__tests__/ShowcaseCard.test.tsx
@@ -55,4 +55,12 @@ describe('ShowcaseCard image loading', () => {
     expect(onNavigate).toHaveBeenCalledWith('letter-1', 'image-1');
   });
 
+  it('keeps admin previews without a navigation handler free of link destinations', () => {
+    const { container } = render(<ShowcaseCard items={items} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(container.querySelector('[href]')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/image-1.jpg');
+  });
+
 });

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -611,3 +611,15 @@
     margin-top: 0.6rem;
   }
 }
+
+.home-hero-open-link {
+  position: absolute;
+  inset: 0;
+  color: inherit;
+  text-decoration: none;
+  border-radius: inherit;
+}
+.home-hero-open-link:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: -4px;
+}

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -613,6 +613,7 @@
 }
 
 .home-hero-open-link {
+  -webkit-touch-callout: default;
   position: absolute;
   inset: 0;
   color: inherit;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -131,11 +131,12 @@ function HeroLetterCard({
   const letterParams = new URLSearchParams({ from: 'highlight' });
   if (currentImage) letterParams.set('image', currentImage.id);
   const navigateToLetter = (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    const start = pointerStartRef.current;
+    pointerStartRef.current = null;
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
-    // Suppress click if pointer moved (user was scrolling/swiping)
-    const start = pointerStartRef.current;
-    if (start && e) {
+    // Keyboard clicks have no pointer coordinates and must not inherit a prior drag.
+    if (start && e.detail > 0) {
       const dx = Math.abs(e.clientX - start.x);
       const dy = Math.abs(e.clientY - start.y);
       if (dx > 8 || dy > 8) return;
@@ -178,6 +179,7 @@ function HeroLetterCard({
         href={`/letter/${heroLetter.id}?${letterParams.toString()}`}
         aria-label={ariaLabel}
         onPointerDown={handlePointerDown}
+        onPointerCancel={() => { pointerStartRef.current = null; }}
         onClick={navigateToLetter}
       >
       {heroImages.length > 0 ? (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,6 @@ import {
   useEffect,
   useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useNavigate, Link } from "react-router-dom";
@@ -129,7 +128,11 @@ function HeroLetterCard({
   const handlePointerDown = (e: React.PointerEvent) => {
     pointerStartRef.current = { x: e.clientX, y: e.clientY };
   };
-  const navigateToLetter = (e?: ReactMouseEvent) => {
+  const letterParams = new URLSearchParams({ from: 'highlight' });
+  if (currentImage) letterParams.set('image', currentImage.id);
+  const navigateToLetter = (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    e.preventDefault();
     // Suppress click if pointer moved (user was scrolling/swiping)
     const start = pointerStartRef.current;
     if (start && e) {
@@ -141,13 +144,6 @@ function HeroLetterCard({
     params.set("from", "highlight");
     if (currentImage) params.set("image", currentImage.id);
     onNavigate(heroLetter.id, params);
-  };
-  const handleCardKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget) return;
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      navigateToLetter();
-    }
   };
   const handlePrevPage = (event: ReactMouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -175,15 +171,15 @@ function HeroLetterCard({
 
   return (
     <div
-      role="button"
-      tabIndex={0}
       className={`letter-card home-hero-feature-card letter-card--${heroLetter.imageType || 'letter'}`}
-      aria-label={ariaLabel}
-      onPointerDown={handlePointerDown}
-      onClick={navigateToLetter}
-      onKeyDown={handleCardKeyDown}
       onMouseEnter={handleHeroHover}
     >
+      <a className="home-hero-open-link"
+        href={`/letter/${heroLetter.id}?${letterParams.toString()}`}
+        aria-label={ariaLabel}
+        onPointerDown={handlePointerDown}
+        onClick={navigateToLetter}
+      >
       {heroImages.length > 0 ? (
         heroImages.map((img, idx) => (
           <ProgressiveImage
@@ -232,6 +228,7 @@ function HeroLetterCard({
         {heroDate && <div className="letter-card-date">{heroDate}</div>}
         {heroLetter.hook && <p className="letter-hook">{heroLetter.hook}</p>}
       </div>
+      </a>
       {hasMultiplePages && (
         <>
           <button

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -174,7 +174,7 @@ function HeroLetterCard({
       className={`letter-card home-hero-feature-card letter-card--${heroLetter.imageType || 'letter'}`}
       onMouseEnter={handleHeroHover}
     >
-      <a className="home-hero-open-link"
+      <a className="home-hero-open-link" data-carousel-drag draggable={false}
         href={`/letter/${heroLetter.id}?${letterParams.toString()}`}
         aria-label={ariaLabel}
         onPointerDown={handlePointerDown}
@@ -378,7 +378,7 @@ export default function HomePage() {
       />
       {isMobile && (heroLetter || !heroLoaded) ? (
         <section className="home-hero home-hero--carousel">
-          <InfiniteCarousel classPrefix="hero-carousel" pauseRef={carouselPauseRef}>
+          <InfiniteCarousel classPrefix="hero-carousel" pauseRef={carouselPauseRef} suppressClickAfterDrag>
             {[
               <div className="home-hero-copy" key="copy">
                 <p className="home-kicker">{heroCopy.kicker}</p>

--- a/frontend/src/pages/__tests__/CollectionDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/CollectionDetailPage.test.tsx
@@ -225,10 +225,11 @@ describe("CollectionDetailPage", () => {
       renderCollectionDetailPage();
 
       await screen.findByRole("heading", { name: "Collection Nine" });
-      const highlightButtons = screen.getAllByRole("button").filter(
-        (btn) => btn.classList.contains("cd-highlight-card"),
+      const highlightLinks = screen.getAllByRole("link").filter(
+        (link) => link.classList.contains("cd-highlight-open-link"),
       );
-      await user.click(highlightButtons[0]);
+      expect(highlightLinks[0]).toHaveAttribute('href', expect.stringContaining('/letter/letter-2'));
+      await user.click(highlightLinks[0]);
 
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.stringContaining("/letter/letter-2"),

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -167,6 +167,9 @@ describe("HomePage archive browsing", () => {
     await user.click(screen.getByRole("button", { name: "Next page" }));
 
     expect(await screen.findByText("2/2")).toBeInTheDocument();
+    const featureLink = document.querySelector('.home-hero-open-link');
+    expect(featureLink).toHaveAttribute('href', '/letter/featured-letter?from=highlight&image=page-2');
+    expect(screen.getByRole('button', { name: 'Next page' }).closest('a')).toBeNull();
   });
 
   it("smoothly scrolls the hero CTA to the full search panel below the header", async () => {

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import HomePage from "../HomePage";
 import { HeaderDockProvider } from "../../contexts/HeaderDockContext";
 import type { ArchiveShelfItem } from "../../types/Letter";
+
+function LocationProbe() { const location = useLocation(); return <output data-testid="location">{location.pathname}</output>; }
 
 const listBlogPostsMock = vi.fn();
 const searchArchiveShelfMock = vi.fn();
@@ -158,6 +160,7 @@ describe("HomePage archive browsing", () => {
       <MemoryRouter>
         <HeaderDockProvider>
           <HomePage />
+          <LocationProbe />
         </HeaderDockProvider>
       </MemoryRouter>,
     );
@@ -170,6 +173,9 @@ describe("HomePage archive browsing", () => {
     const featureLink = document.querySelector('.home-hero-open-link');
     expect(featureLink).toHaveAttribute('href', '/letter/featured-letter?from=highlight&image=page-2');
     expect(screen.getByRole('button', { name: 'Next page' }).closest('a')).toBeNull();
+    fireEvent(featureLink!, new MouseEvent('pointerdown', { bubbles: true, clientX: 300, clientY: 200 }));
+    fireEvent.click(featureLink!, { detail: 0, clientX: 0, clientY: 0 });
+    expect(screen.getByTestId('location')).toHaveTextContent('/letter/featured-letter');
   });
 
   it("smoothly scrolls the hero CTA to the full search panel below the header", async () => {

--- a/frontend/src/pages/admin/AdminCollectionPage.tsx
+++ b/frontend/src/pages/admin/AdminCollectionPage.tsx
@@ -915,6 +915,7 @@ function AdminCollectionRoute({
                       className={`acp-picker-card${letter.id === featuredLetterId ? ' acp-picker-card--selected' : ''}`}
                     >
                       <LetterCard
+                        selection
                         card={buildLetterCardData(letter)}
                         onClick={handleSelectFeaturedLetter}
                       />

--- a/frontend/src/pages/admin/AdminCollectionPage.tsx
+++ b/frontend/src/pages/admin/AdminCollectionPage.tsx
@@ -1001,7 +1001,6 @@ function AdminCollectionRoute({
                   </div>
                   <ShowcaseCard
                     items={showcaseItems}
-                    onNavigate={() => {/* no-op on admin — no navigation */}}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/admin/ContentPage.tsx
+++ b/frontend/src/pages/admin/ContentPage.tsx
@@ -962,6 +962,7 @@ function HomepageTab() {
                       className={`fl-picker-card${item.id === featured?.letter_id ? ' fl-picker-card--selected' : ''}`}
                     >
                       <LetterCard
+                        selection
                         card={item}
                         onClick={(id) => void handleSelectFeatured(id)}
                       />


### PR DESCRIPTION
Archive cards, collection highlights, and homepage featured cards now expose real destinations for native keyboard, copy-link, and new-tab behavior. Ordinary clicks keep in-app navigation; admin selection cards remain buttons. Highlight and hero page controls are sibling buttons, and destinations track the selected image.

Carousel drag suppression is cleared between gestures and never blocks keyboard activation. Retain active-only showcase image loading and the homepage's three-image window. Validation: all 1,136 frontend tests and the production build pass, including keyboard highlight controls and modifier-click behavior. Browser regressions cover middle-click opening and Back/Forward search history. Earlier combined validation passed all 83 mocked browser tests; current-base CI repeats those checks before merge.
