### PR TITLE
Clarify public loading and reader navigation

### DIFF
--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -32,7 +32,7 @@ type SortOrder = 'asc' | 'desc';
 
 const SORT_OPTIONS: { field: SortField; label: string; defaultOrder: SortOrder }[] = [
   { field: 'number', label: 'Collection', defaultOrder: 'asc' },
-  { field: 'letters', label: 'Letter count', defaultOrder: 'desc' },
+  { field: 'letters', label: 'Item count', defaultOrder: 'desc' },
   { field: 'date', label: 'Date', defaultOrder: 'desc' },
   { field: 'title', label: 'Title', defaultOrder: 'asc' },
 ];
@@ -141,14 +141,16 @@ export default function CollectionsPage() {
             a love story told across distance. Pick one and step inside.
           </p>
           <div className="collections-hero-bottom">
-            <div className="collections-summary">
+            <div className="collections-summary" aria-busy={loading}>
+              {showLoadingShell ? <span className="summary-stat">Loading collection totals…</span> : error ? <span className="summary-stat">Collection totals unavailable</span> : <>
               <span className="summary-stat">
                 <strong>{collections.length}</strong> collection{collections.length !== 1 ? 's' : ''}
               </span>
               <span className="summary-divider">/</span>
               <span className="summary-stat">
-                <strong>{totalLetters}</strong> letters
+                <strong>{totalLetters}</strong> archive item{totalLetters !== 1 ? 's' : ''}
               </span>
+              </>}
             </div>
             <div className="collections-sort" ref={sortRef} onKeyDown={(e) => { if (e.key === 'Escape') setSortOpen(false); }}>
               <button
@@ -265,7 +267,7 @@ export default function CollectionsPage() {
                         <p className="collection-card-teaser">{teaser}</p>
                       )}
 
-                      <span className="collection-card-cta">Read the letters &rarr;</span>
+                      <span className="collection-card-cta">Explore the collection &rarr;</span>
                     </Link>
                   );
                 })}

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -245,7 +245,7 @@ export default function CollectionsPage() {
                         <span className="collection-card-count">
                           {isMobile
                             ? collection.letterCount
-                            : `${collection.letterCount} letter${collection.letterCount !== 1 ? 's' : ''}`}
+                            : `${collection.letterCount} item${collection.letterCount !== 1 ? 's' : ''}`}
                         </span>
                       </div>
 

--- a/frontend/src/pages/LetterDetailPage.css
+++ b/frontend/src/pages/LetterDetailPage.css
@@ -1172,3 +1172,18 @@
   }
 }
 
+
+.letter-content-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin-top: 1rem;
+}
+.letter-content-links a {
+  color: inherit;
+  text-underline-offset: 0.2em;
+}
+#letter-transcript,
+#letter-scans {
+  scroll-margin-top: calc(var(--header-height, 5rem) + 1rem);
+}

--- a/frontend/src/pages/LetterDetailPage.tsx
+++ b/frontend/src/pages/LetterDetailPage.tsx
@@ -453,6 +453,12 @@ export default function LetterDetailPage() {
             <p className="letter-dateline">{formatDateText(dateline)}</p>
           )}
 
+          {(hasTranscript || carouselImages.length > 0) && (
+            <nav className="letter-content-links" aria-label="On this page">
+              {hasTranscript && <a href="#letter-transcript">Read transcript</a>}
+              {carouselImages.length > 0 && <a href="#letter-scans">View original scans</a>}
+            </nav>
+          )}
         </header>
 
         {/* ── 2. Summary ───────────────────────────────────── */}
@@ -465,7 +471,7 @@ export default function LetterDetailPage() {
 
         {/* ── 3. Scan Image Carousel ──────────────────────── */}
         {carouselImages.length > 0 && (
-          <figure className="letter-scan-figure">
+          <figure id="letter-scans" className="letter-scan-figure" tabIndex={-1}>
             <div className="scan-carousel" ref={carouselRef} data-swipe-ignore>
               {carouselImages.map((img, idx) => {
                 const isLetter = img.type === "letter";
@@ -532,7 +538,7 @@ export default function LetterDetailPage() {
 
         {/* ── 4. Transcript ────────────────────────────────── */}
         {hasTranscript && (
-          <section className={`letter-transcript-section${transcriptSectionClass}${transcriptMode === "original" ? " transcript-original-mode" : ""}`} ref={transcriptSectionRef}>
+          <section id="letter-transcript" tabIndex={-1} className={`letter-transcript-section${transcriptSectionClass}${transcriptMode === "original" ? " transcript-original-mode" : ""}`} ref={transcriptSectionRef}>
             <div className="transcript-header-row">
               <div className="transcript-label">Transcript</div>
               {letter.transcriptStatus === "VERIFIED" ? (

--- a/frontend/src/pages/SupportPage.tsx
+++ b/frontend/src/pages/SupportPage.tsx
@@ -46,6 +46,9 @@ export default function SupportPage() {
         style={{ width: '100%', textAlign: 'left', display: 'flex', flexDirection: 'column', gap: '1.2rem' }}
         onClickCapture={handleSupportActionClick}
       >
+        <aside aria-label="Support availability" style={{ padding: '1rem 1.25rem', border: '1px solid currentColor', borderRadius: '0.75rem' }}>
+          Donation and contact options are coming soon. Links on this page are not active yet.
+        </aside>
         <BlockRenderer blocks={blocks} siteSettings={settings} />
       </div>
       <Modal


### PR DESCRIPTION
Show loading/unavailable collection totals instead of misleading zero counts, and label mixed-media counts as archive items. Make inactive donation/contact links clear before visitors click them. Add direct shortcuts past long summaries to the available transcript and original scans, with scroll spacing for the fixed header.

Validation: 13 relevant page tests and the frontend production build pass. Existing support channels remain inactive.
