### PR TITLE
Load lightweight public collection overviews

### DIFF
--- a/backend/src/routes/__tests__/collections.integration.test.ts
+++ b/backend/src/routes/__tests__/collections.integration.test.ts
@@ -431,6 +431,22 @@ describe('collections route integration', () => {
     ]);
   });
 
+  it('returns an overview without loading or exposing reading and processing payloads', async () => {
+    getCollectionByCodeMock.mockResolvedValueOnce({ id: 'collection-9', collectionCode: '009', title: 'Nine', description: null, createdAt: '2024-01-01', hook: null, profileStatus: 'EMPTY' });
+    lettersFindManyMock.mockResolvedValueOnce([{ id: 'letter-1', dateRaw: '19470810', typeSequence: 1, type: 'L' }]);
+    transformLettersWithRelatedToDTOMock.mockReturnValueOnce([{ id: 'letter-1', images: [], metadata: { sender: 'Alice', hook: 'A preview', verified: true, description: 'Long summary' }, transcriptStatus: 'VERIFIED', metadataContentStatus: 'VERIFIED', transcript: { fullText: 'Long transcript' }, readingText: 'Long reading text' }]);
+    const response = await invokeRouter(collectionsRouter, { method: 'GET', url: '/collections/009', query: { view: 'overview' } });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({ letterCount: 1, letters: [{ id: 'letter-1', metadata: { sender: 'Alice', hook: 'A preview', verified: true } }] });
+    const item = (response.body as { letters: Record<string, unknown>[] }).letters[0];
+    expect(item).not.toHaveProperty('transcript');
+    expect(item).not.toHaveProperty('readingText');
+    expect(item.metadata).not.toHaveProperty('description');
+    const query = lettersFindManyMock.mock.calls[0][0];
+    expect(query.columns).toMatchObject({ transcriptionText: false, transcriptionJson: false, metadataV2Json: false });
+    expect(query.with.pages.columns.lineSegments).toBe(false);
+  });
+
   it('withholds a detail hook revoked after the collection and letters are read', async () => {
     getCollectionByCodeMock.mockResolvedValueOnce({
       id: 'collection-9',

--- a/backend/src/routes/collections.ts
+++ b/backend/src/routes/collections.ts
@@ -1,3 +1,4 @@
+import { toPublicCollectionItem } from '../services/public-collection-overview.js';
 import { Router } from 'express';
 import { eq, and, sql, asc } from 'drizzle-orm';
 import { db, letters, collections } from '../db/index.js';
@@ -206,15 +207,23 @@ router.get('/collections/:code', async (req, res, next) => {
       return;
     }
 
-    // Get published letters in this collection
+    const overview = req.query.view === 'overview';
+    // Overview requests omit processing payloads and reading text at the database boundary.
     const allLetters = await db.query.letters.findMany({
       where: and(
         eq(letters.collectionId, collection.id),
         eq(letters.visibility, 'PUBLISHED')
       ),
+      ...(overview ? { columns: {
+        transcriptionText: false, transcriptionJson: false, readingText: false,
+        extraContentTranscript: false, metadataJson: false, metadataV2Json: false,
+        entityExtractionJson: false, aiNotes: false, notes: false, summary: false,
+        metadataConfirmationGuidance: false,
+      } as const } : {}),
       with: {
-        collection: true,
+        collection: { columns: { title: true, collectionCode: true } },
         pages: {
+          ...(overview ? { columns: { lineSegments: false } as const } : {}),
           orderBy: (p, { asc }) => [asc(p.pageNumber)],
         },
       },
@@ -271,7 +280,7 @@ router.get('/collections/:code', async (req, res, next) => {
       && await collectionProfilePublicationIsCurrent(collection.id);
     const result = {
       ...toPublicCollection(collection, profileSourceCurrent),
-      letters: collectionLetters,
+      letters: overview ? collectionLetters.map(toPublicCollectionItem) : collectionLetters,
       letterCount: collectionLetters.length,
     };
     res.json(result);

--- a/backend/src/services/public-collection-overview.ts
+++ b/backend/src/services/public-collection-overview.ts
@@ -1,0 +1,14 @@
+import type { PublicLetter } from './public-read-model.js';
+
+/** Collection browsing needs previews and image identities, not reading payloads. */
+export function toPublicCollectionItem(letter: PublicLetter) {
+  const { sender, recipient, date, dateRaw, hook, verified } = letter.metadata;
+  return {
+    id: letter.id,
+    images: letter.images,
+    metadata: { sender, recipient, date, dateRaw, hook, verified },
+    transcriptStatus: letter.transcriptStatus,
+    metadataContentStatus: letter.metadataContentStatus,
+    photoDescription: letter.photoDescription,
+  };
+}

--- a/docs/site-improvements/collection-overview-measurements.json
+++ b/docs/site-improvements/collection-overview-measurements.json
@@ -1,0 +1,13 @@
+{
+  "collection": "009",
+  "items": 24,
+  "before": {
+    "jsonBytes": 57027,
+    "gzipBytes": 10936
+  },
+  "after": {
+    "jsonBytes": 14987,
+    "gzipBytes": 3655
+  },
+  "method": "Same published API response projected to overview, gzip default settings; excludes transport headers."
+}

--- a/frontend/src/api/collections.ts
+++ b/frontend/src/api/collections.ts
@@ -18,8 +18,12 @@ export interface CollectionInfo {
   primaryRecipient?: string | null;
 }
 
+export type PublicCollectionItem = Pick<PublicLetter,
+  'id' | 'images' | 'transcriptStatus' | 'metadataContentStatus' | 'photoDescription'
+> & { metadata: Pick<PublicLetter['metadata'], 'sender' | 'recipient' | 'date' | 'dateRaw' | 'hook' | 'verified'> };
+
 export interface CollectionWithLetters extends CollectionInfo {
-  letters: PublicLetter[];
+  letters: PublicCollectionItem[];
   profileNarrative?: string | null;
   profileStatus?: ContentStatus;
   profileStartHereLetterId?: string | null;
@@ -95,7 +99,7 @@ export async function listCollections(): Promise<CollectionInfo[]> {
  * Fetch a single collection by code (public - only includes published letters)
  */
 export async function getCollectionByCode(code: string): Promise<CollectionWithLetters> {
-  return apiGet<CollectionWithLetters>(`/collections/${code}`);
+  return apiGet<CollectionWithLetters>(`/collections/${code}?view=overview`);
 }
 
 /**

--- a/frontend/src/pages/collection-detail-utils.ts
+++ b/frontend/src/pages/collection-detail-utils.ts
@@ -1,17 +1,8 @@
-import type { CollectionProfileCorrespondent, KeyPerson } from "../api/collections";
-import type { LetterImageType, PublicLetter } from "../types/Letter";
+import type { CollectionProfileCorrespondent, KeyPerson, PublicCollectionItem } from "../api/collections";
+import type { LetterImageType } from "../types/Letter";
 import { getMediaLabel, getPrimaryMediaType } from "../utils/letterPreview";
 
-/** Fields shared by public projections and full admin letters in collection UI. */
-type CollectionLetter = Pick<
-  PublicLetter,
-  | "id"
-  | "images"
-  | "metadata"
-  | "transcriptStatus"
-  | "metadataContentStatus"
-  | "photoDescription"
->;
+type CollectionLetter = PublicCollectionItem;
 
 /* ------------------------------------------------------------------ */
 /*  Stats                                                              */


### PR DESCRIPTION
Collection browsing now requests an explicit overview projection. Database queries omit reading text, processing JSON, line-segment payloads, and private notes; the response contains only the image identities, dates, preview text, and verification status the collection UI needs. Default full collection responses and individual letter detail remain available.

For the same published collection 009 response, JSON falls from 57,027 to 14,987 bytes and gzip from 10,936 to 3,655 bytes (about 67% smaller compressed). This measures serialized payload size, not production latency. Validation: 17 backend route tests, 100 related frontend tests, backend typecheck, and frontend build pass. Regression checks ensure excluded fields never enter the overview query/response.
