### PR TITLE
Render the homepage feature without unrelated request delays

### DIFF
--- a/backend/src/routes/__tests__/content-pages.integration.test.ts
+++ b/backend/src/routes/__tests__/content-pages.integration.test.ts
@@ -228,6 +228,7 @@ describe('public content pages route', () => {
     };
     const publicRepresentative = {
       id: 'representative-letter',
+      imageUrl: '/images/first-page?v=12345678',
       hook: 'Current public hook',
       summary: 'Current public summary',
       letterDate: null,
@@ -272,6 +273,10 @@ describe('public content pages route', () => {
       imageType: 'L',
       source: 'auto',
     });
+    const projection = selectMock.mock.calls[2][0];
+    expect(projection.imageUrl.strings.join(' ')).toContain('ORDER BY preview.page_number ASC');
+    expect(projection.imageUrl.values).toEqual(['letters.id']);
+    expect(response.body).toMatchObject({ imageUrl: '/images/first-page?v=12345678' });
     expect(insertMock).toHaveBeenCalledTimes(1);
     const insertBuilder = insertMock.mock.results[0]?.value as {
       values: ReturnType<typeof vi.fn>;

--- a/backend/src/routes/content-pages.ts
+++ b/backend/src/routes/content-pages.ts
@@ -20,6 +20,15 @@ router.get('/content/featured-letter', async (req, res) => {
       const [letter] = await db
         .select({
           id: letters.id,
+          imageUrl: sql<string | null>`(
+            SELECT '/images/' || preview.id::text ||
+              CASE WHEN preview.checksum_sha256 IS NOT NULL
+                THEN '?v=' || LEFT(preview.checksum_sha256, 8) ELSE '' END
+            FROM letter_pages preview
+            WHERE preview.letter_id = ${letters.id}
+            ORDER BY preview.page_number ASC
+            LIMIT 1
+          )`,
           hook: sql`CASE
             WHEN ${letters.metadataPublished} THEN ${letters.hook}
             WHEN ${letters.type} = 'P'

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -14,7 +14,6 @@ import Footer from "../components/Footer/Footer";
 import BackToSearch from "../components/BackToSearch";
 import { getContentPage, getFeaturedLetter, getImageUrl, listBlogPosts, type BlogPost, type FeaturedLetter } from "../api/client";
 import { ProgressiveImage } from "../components/common";
-import { imagePreloadService } from "../services/imagePreloadService";
 import { getLetterById } from "../api/letters";
 import type { LetterImage } from "../types/Letter";
 import { buildHomeSeo } from "../utils/seo";
@@ -162,17 +161,6 @@ function HeroLetterCard({
     onInteraction?.();
   };
 
-  const handleHeroHover = () => {
-    // Preload all hero images at carousel width for instant letter detail view
-    for (const img of heroImages) {
-      const url = getImageUrl(img.imageUrl, { width: 800 });
-      if (!imagePreloadService.isPreloaded(url)) {
-        const preload = new Image();
-        preload.src = url;
-      }
-    }
-  };
-
   return (
     <div
       role="button"
@@ -182,10 +170,13 @@ function HeroLetterCard({
       onPointerDown={handlePointerDown}
       onClick={navigateToLetter}
       onKeyDown={handleCardKeyDown}
-      onMouseEnter={handleHeroHover}
     >
       {heroImages.length > 0 ? (
-        heroImages.map((img, idx) => (
+        heroImages.map((img, idx) => {
+          const previous = (heroPageIndex + heroImages.length - 1) % heroImages.length;
+          const next = (heroPageIndex + 1) % heroImages.length;
+          if (idx !== heroPageIndex && idx !== previous && idx !== next) return null;
+          return (
           <ProgressiveImage
             key={img.id}
             className="letter-card-image"
@@ -193,14 +184,15 @@ function HeroLetterCard({
             thumbSrc={getImageUrl(img.imageUrl, { width: 32 })}
             midSrc={getImageUrl(img.imageUrl, { width: 480 })}
             alt={`Scan of letter${heroLetter.sender ? ` from ${heroLetter.sender}` : ''}${heroLetter.recipient ? ` to ${heroLetter.recipient}` : ''}`}
-            loading={idx === 0 ? "eager" : "lazy"}
-            fetchPriority={idx === 0 ? "high" : undefined}
+            loading={idx === heroPageIndex ? "eager" : "lazy"}
+            fetchPriority={idx === heroPageIndex ? "high" : undefined}
             decoding="async"
             style={{ opacity: idx === heroPageIndex ? 1 : 0 }}
             idleUpgrade
             context="hero"
           />
-        ))
+        );
+        })
       ) : heroLetter.imageUrl ? (
         <ProgressiveImage
           className="letter-card-image"
@@ -296,38 +288,32 @@ export default function HomePage() {
   useEffect(() => {
     let cancelled = false;
 
-    // Start featured letter fetch, and eagerly chain getLetterById as soon as it resolves
-    // (don't wait for blogPosts/contentPage before fetching images)
+    // Independent content must not hold up the featured image's first paint.
     const featuredPromise = getFeaturedLetter().catch(() => null);
-    const imagesPromise = featuredPromise.then((featured) => {
-      if (!featured || cancelled) return null;
-      return getLetterById(featured.id).catch(() => null);
-    });
-
-    Promise.all([
-      listBlogPosts({ limit: 1 }).catch(() => ({ posts: [], total: 0 })),
-      featuredPromise,
-      getContentPage('home').catch(() => null),
-      imagesPromise,
-    ]).then(([blogData, featured, homePage, letterDetails]) => {
+    featuredPromise.then((featured) => {
       if (cancelled) return;
-      if (blogData.posts.length > 0) setLatestBlogPost(blogData.posts[0]);
-      if (homePage) {
-        const json = homePage.contentJson as { hero?: { kicker?: string; heading?: string; subtitle?: string } };
-        if (json?.hero) {
-          setHeroCopy((prev) => ({
-            kicker: json.hero!.kicker || prev.kicker,
-            heading: json.hero!.heading || prev.heading,
-            subtitle: json.hero!.subtitle || prev.subtitle,
-          }));
-        }
-      }
       setHeroLetter(featured);
       setHeroLoaded(true);
-      if (featured) {
-        setHeroImages(letterDetails?.images || []);
-      }
     });
+    featuredPromise.then(async (featured) => {
+      if (!featured || cancelled) return;
+      const details = await getLetterById(featured.id).catch(() => null);
+      if (!cancelled) setHeroImages(details?.images || []);
+    });
+    listBlogPosts({ limit: 1 }).then((data) => {
+      if (!cancelled && data.posts.length) setLatestBlogPost(data.posts[0]);
+    }).catch(() => {});
+    getContentPage('home').then((homePage) => {
+      if (cancelled || !homePage) return;
+      const json = homePage.contentJson as { hero?: { kicker?: string; heading?: string; subtitle?: string } };
+      if (json?.hero) {
+        setHeroCopy((prev) => ({
+          kicker: json.hero!.kicker || prev.kicker,
+          heading: json.hero!.heading || prev.heading,
+          subtitle: json.hero!.subtitle || prev.subtitle,
+        }));
+      }
+    }).catch(() => {});
 
     return () => { cancelled = true; };
   }, []);

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -236,6 +236,26 @@ describe("HomePage archive browsing", () => {
     expect(scrollToMock).toHaveBeenLastCalledWith(0, 868);
   });
 
+  it("shows the featured card while unrelated content and detail requests are pending", async () => {
+    getFeaturedLetterMock.mockResolvedValueOnce({ id: 'featured-letter', hook: 'Ready to read', imageUrl: '/images/first-page', imageType: 'letter' });
+    const pending = new Promise(() => {});
+    listBlogPostsMock.mockReturnValueOnce(pending);
+    getContentPageMock.mockReturnValueOnce(pending);
+    getLetterByIdMock.mockReturnValueOnce(pending);
+    render(<MemoryRouter><HeaderDockProvider><HomePage /></HeaderDockProvider></MemoryRouter>);
+    expect(await screen.findByText('Ready to read')).toBeInTheDocument();
+  });
+
+  it("keeps only the current and adjacent featured page images mounted", async () => {
+    getFeaturedLetterMock.mockResolvedValueOnce({ id: 'featured-letter', hook: 'A long letter', imageUrl: '/images/first-page', imageType: 'letter' });
+    getLetterByIdMock.mockResolvedValueOnce({ images: Array.from({ length: 30 }, (_, index) => ({ id: `page-${index}`, type: 'letter', imageUrl: `/images/page-${index}` })) });
+    render(<MemoryRouter><HeaderDockProvider><HomePage /></HeaderDockProvider></MemoryRouter>);
+    expect(await screen.findByText('1/30')).toBeInTheDocument();
+    expect(document.querySelectorAll('.home-hero-feature-card .letter-card-image')).toHaveLength(3);
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Next page' }));
+    expect(document.querySelectorAll('.home-hero-feature-card .letter-card-image')).toHaveLength(3);
+  });
+
   it("formats featured letter dates into human-readable month names", async () => {
     getFeaturedLetterMock.mockResolvedValueOnce({
       id: "featured-letter",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,30 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
+
+// Start the API handshake while the browser loads the application modules.
+function apiConnectionHint(): Plugin {
+  let origin: string | undefined;
+  return {
+    name: 'api-connection-hint',
+    configResolved({ env }) {
+      const configured = env.VITE_API_URL;
+      if (typeof configured !== 'string' || !URL.canParse(configured)) return;
+      const url = new URL(configured);
+      if (url.protocol === 'https:' || url.protocol === 'http:') origin = url.origin;
+    },
+    transformIndexHtml() {
+      return origin ? [{
+        tag: 'link',
+        attrs: { rel: 'preconnect', href: origin, crossorigin: 'use-credentials' },
+        injectTo: 'head',
+      }] : [];
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), apiConnectionHint()],
   server: {
     port: 5174,
     // Force browser to always check for updates in development


### PR DESCRIPTION
A slow journal, editable-copy, or letter-detail request held up the homepage feature. Fetch these independently and include the first-page preview in every public featured-letter response, so the available feature can render before the slower content resolves.

Mount only the current and neighboring featured scans, remove all-page hover preloading, and add an initial HTML connection hint for the configured API origin. Relative API configurations do not add an external hint; credential mode matches the API client.

Validation: seven homepage regressions and four backend endpoint checks pass, including a stalled secondary-request case and a 30-page feature mounting only three scans. Backend typecheck and frontend production builds pass. Actual builds verified external and relative API configurations. Required CI checks run on the combined revision; no standalone latency gain is claimed for the connection hint.
