### PR TITLE
Defer offscreen catalogue images and inactive showcase scans

### DIFF
--- a/frontend/src/components/ShowcaseCard.tsx
+++ b/frontend/src/components/ShowcaseCard.tsx
@@ -47,7 +47,7 @@ export default function ShowcaseCard({ items, onNavigate, onInteraction }: Showc
       onClick={() => onNavigate(item.letterId, item.imageId)}
     >
       {items.map((gi, idx) => (
-        gi.imageUrl ? (
+        idx === index && gi.imageUrl ? (
           <ProgressiveImage
             key={gi.imageId || idx}
             className="cd-highlight-img"
@@ -55,8 +55,8 @@ export default function ShowcaseCard({ items, onNavigate, onInteraction }: Showc
             thumbSrc={getImageUrl(gi.imageUrl, { width: 32 })}
             midSrc={getImageUrl(gi.imageUrl, { width: 320 })}
             alt={idx === index ? (gi.hook || gi.label) : ''}
-            loading={idx === 0 ? 'eager' : 'lazy'}
-            fetchPriority={idx === 0 ? 'high' : undefined}
+            loading="eager"
+            fetchPriority="high"
             style={{ opacity: idx === index ? 1 : 0 }}
             idleUpgrade
             context="showcase"

--- a/frontend/src/components/__tests__/ShowcaseCard.test.tsx
+++ b/frontend/src/components/__tests__/ShowcaseCard.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ShowcaseCard, { type ShowcaseItem } from '../ShowcaseCard';
+
+vi.mock('../common', () => ({
+  ProgressiveImage: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+vi.mock('../../api/client', () => ({ getImageUrl: (url: string) => url }));
+
+const items: ShowcaseItem[] = Array.from({ length: 100 }, (_, index) => ({
+  letterId: `letter-${index}`, imageId: `image-${index}`, imageUrl: `/image-${index}.jpg`,
+  label: `Scan ${index}`, peopleLine: '', date: '', hook: '', mediaType: 'letter',
+}));
+
+describe('ShowcaseCard image loading', () => {
+  it('mounts only the active scan and keeps navigation and wrapping functional', () => {
+    const onNavigate = vi.fn();
+    render(<ShowcaseCard items={items} onNavigate={onNavigate} />);
+    expect(screen.getAllByRole('img')).toHaveLength(1);
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/image-0.jpg');
+    fireEvent.click(screen.getByLabelText('Next'));
+    expect(screen.getAllByRole('img')).toHaveLength(1);
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/image-1.jpg');
+    fireEvent.click(screen.getByRole('button'));
+    expect(onNavigate).toHaveBeenCalledWith('letter-1', 'image-1');
+    fireEvent.click(screen.getByLabelText('Previous'));
+    fireEvent.click(screen.getByLabelText('Previous'));
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/image-99.jpg');
+  });
+});

--- a/frontend/src/components/common/ProgressiveImage.tsx
+++ b/frontend/src/components/common/ProgressiveImage.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useState, useEffect, useRef, type CSSProperties } from 'react';
 import { useProgressiveImage } from '../../hooks/useProgressiveImage';
 import './ProgressiveImage.css';
+import { getAppScrollRootForIO } from '../../utils/appScroll';
 
 export interface ProgressiveImageProps {
   src: string;
@@ -67,7 +68,7 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
           setHasBeenVisible(true);
           observer.disconnect();
         }
-      }, { rootMargin: '200px' });
+      }, { root: getAppScrollRootForIO(), rootMargin: '200px' });
       if (containerRef.current) observer.observe(containerRef.current);
       return () => observer.disconnect();
     }, [enabled]);

--- a/frontend/src/components/common/ProgressiveImage.tsx
+++ b/frontend/src/components/common/ProgressiveImage.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState, useEffect, type CSSProperties } from 'react';
+import { forwardRef, useState, useEffect, useRef, type CSSProperties } from 'react';
 import { useProgressiveImage } from '../../hooks/useProgressiveImage';
 import './ProgressiveImage.css';
 
@@ -51,12 +51,33 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
     },
     ref,
   ) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [hasBeenVisible, setHasBeenVisible] = useState(false);
+    const needsVisibility = loading === 'lazy' || deferFullUntilVisible;
+    const enabled = !needsVisibility || hasBeenVisible;
+
+    useEffect(() => {
+      if (enabled) return;
+      if (typeof IntersectionObserver === 'undefined') {
+        setHasBeenVisible(true);
+        return;
+      }
+      const observer = new IntersectionObserver((entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setHasBeenVisible(true);
+          observer.disconnect();
+        }
+      }, { rootMargin: '200px' });
+      if (containerRef.current) observer.observe(containerRef.current);
+      return () => observer.disconnect();
+    }, [enabled]);
+
     const { thumbLoaded, midLoaded, fullLoaded, currentSrc, naturalWidth, naturalHeight } = useProgressiveImage({
       thumbSrc,
       midSrc,
       fullSrc: src,
       idleUpgrade,
-      deferFullUntilVisible,
+      enabled,
       context,
       fullDelay,
     });
@@ -85,7 +106,7 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
     };
 
     return (
-      <div className={`progressive-image ${className ?? ''}`} style={containerStyle}>
+      <div ref={containerRef} className={`progressive-image ${className ?? ''}`} style={containerStyle}>
         {showPlaceholder && placeholderSrc && (
           <img
             src={placeholderSrc}
@@ -103,7 +124,7 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
         )}
         <img
           ref={ref}
-          src={currentSrc || src}
+          src={enabled ? currentSrc || src : undefined}
           alt={alt}
           className={`progressive-image__full ${imgClassName ?? ''} ${fullLoaded ? '' : 'progressive-image__full--loading'}`}
           style={{ ...imgStyle, objectFit, ...(imgError ? { visibility: 'hidden' as const } : {}) }}

--- a/frontend/src/components/common/ProgressiveImage.tsx
+++ b/frontend/src/components/common/ProgressiveImage.tsx
@@ -53,16 +53,12 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
     ref,
   ) {
     const containerRef = useRef<HTMLDivElement>(null);
-    const [hasBeenVisible, setHasBeenVisible] = useState(false);
+    const [hasBeenVisible, setHasBeenVisible] = useState(() => typeof IntersectionObserver === 'undefined');
     const needsVisibility = loading === 'lazy' || deferFullUntilVisible;
     const enabled = !needsVisibility || hasBeenVisible;
 
     useEffect(() => {
       if (enabled) return;
-      if (typeof IntersectionObserver === 'undefined') {
-        setHasBeenVisible(true);
-        return;
-      }
       const observer = new IntersectionObserver((entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           setHasBeenVisible(true);
@@ -94,9 +90,9 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
     const placeholderSrc = midLoaded && midSrc ? midSrc : thumbLoaded ? thumbSrc : '';
     const isThumbOnly = !midLoaded || !midSrc;
 
-    // Aspect ratio: prefer DB value, fall back to natural dims from thumb
+    // Reserve scan space even when legacy records lack dimensions and loading is deferred.
     const resolvedAspectRatio = knownAspectRatio
-      ?? (naturalWidth && naturalHeight ? naturalWidth / naturalHeight : undefined);
+      ?? (naturalWidth && naturalHeight ? naturalWidth / naturalHeight : 3 / 4);
 
     // Fire onLoad when best quality is ready
     if (fullLoaded && onLoad) onLoad();

--- a/frontend/src/components/common/ProgressiveImage.tsx
+++ b/frontend/src/components/common/ProgressiveImage.tsx
@@ -68,7 +68,7 @@ export const ProgressiveImage = forwardRef<HTMLImageElement, ProgressiveImagePro
           setHasBeenVisible(true);
           observer.disconnect();
         }
-      }, { root: getAppScrollRootForIO(), rootMargin: '200px' });
+      }, { root: containerRef.current?.closest('[data-image-scroll-root]') ?? getAppScrollRootForIO(), rootMargin: '200px' });
       if (containerRef.current) observer.observe(containerRef.current);
       return () => observer.disconnect();
     }, [enabled]);

--- a/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
+++ b/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
@@ -23,7 +23,7 @@ function mockHookReturn(overrides: Partial<ReturnType<typeof useProgressiveImage
 }
 
 describe('ProgressiveImage', () => {
-  it('defers every image tier and the DOM source until a lazy image is near the viewport', () => {
+  it.each([false, true])('defers image tiers until near the applicable scrollport (nested=%s)', (nested) => {
     let notify: IntersectionObserverCallback;
     let options: IntersectionObserverInit | undefined;
     const scrollRoot = document.createElement('div');
@@ -38,8 +38,8 @@ describe('ProgressiveImage', () => {
     } as unknown as typeof IntersectionObserver;
     try {
       mockHookReturn();
-      const { unmount } = render(<ProgressiveImage src="/full.jpg" thumbSrc="/thumb.jpg" midSrc="/mid.jpg" alt="Lazy scan" loading="lazy" />);
-      expect(options).toMatchObject({ root: scrollRoot, rootMargin: '200px' });
+      const { container, unmount } = render(<div data-image-scroll-root={nested ? '' : undefined}><ProgressiveImage src="/full.jpg" thumbSrc="/thumb.jpg" midSrc="/mid.jpg" alt="Lazy scan" loading="lazy" /></div>);
+      expect(options).toMatchObject({ root: nested ? container.firstChild : scrollRoot, rootMargin: '200px' });
       expect(mockUseProgressiveImage).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
       expect(screen.getByAltText('Lazy scan')).not.toHaveAttribute('src');
       act(() => notify([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver));

--- a/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
+++ b/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
@@ -25,16 +25,21 @@ function mockHookReturn(overrides: Partial<ReturnType<typeof useProgressiveImage
 describe('ProgressiveImage', () => {
   it('defers every image tier and the DOM source until a lazy image is near the viewport', () => {
     let notify: IntersectionObserverCallback;
+    let options: IntersectionObserverInit | undefined;
+    const scrollRoot = document.createElement('div');
+    scrollRoot.id = 'app-scroll';
+    document.body.append(scrollRoot);
     const disconnect = vi.fn();
     const OriginalObserver = globalThis.IntersectionObserver;
     globalThis.IntersectionObserver = class {
-      constructor(callback: IntersectionObserverCallback) { notify = callback; }
+      constructor(callback: IntersectionObserverCallback, init?: IntersectionObserverInit) { notify = callback; options = init; }
       observe = vi.fn();
       disconnect = disconnect;
     } as unknown as typeof IntersectionObserver;
     try {
       mockHookReturn();
       const { unmount } = render(<ProgressiveImage src="/full.jpg" thumbSrc="/thumb.jpg" midSrc="/mid.jpg" alt="Lazy scan" loading="lazy" />);
+      expect(options).toMatchObject({ root: scrollRoot, rootMargin: '200px' });
       expect(mockUseProgressiveImage).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
       expect(screen.getByAltText('Lazy scan')).not.toHaveAttribute('src');
       act(() => notify([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver));
@@ -44,6 +49,7 @@ describe('ProgressiveImage', () => {
       expect(disconnect).toHaveBeenCalled();
     } finally {
       globalThis.IntersectionObserver = OriginalObserver;
+      scrollRoot.remove();
     }
   });
 

--- a/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
+++ b/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
@@ -42,6 +42,7 @@ describe('ProgressiveImage', () => {
       expect(options).toMatchObject({ root: nested ? container.firstChild : scrollRoot, rootMargin: '200px' });
       expect(mockUseProgressiveImage).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
       expect(screen.getByAltText('Lazy scan')).not.toHaveAttribute('src');
+      expect(container.querySelector<HTMLElement>('.progressive-image')?.style.aspectRatio).toBe('0.75');
       act(() => notify([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver));
       expect(mockUseProgressiveImage).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: true }));
       expect(screen.getByAltText('Lazy scan')).toHaveAttribute('src', '/full.jpg');

--- a/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
+++ b/frontend/src/components/common/__tests__/ProgressiveImage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ProgressiveImage } from '../ProgressiveImage';
 
@@ -23,6 +23,30 @@ function mockHookReturn(overrides: Partial<ReturnType<typeof useProgressiveImage
 }
 
 describe('ProgressiveImage', () => {
+  it('defers every image tier and the DOM source until a lazy image is near the viewport', () => {
+    let notify: IntersectionObserverCallback;
+    const disconnect = vi.fn();
+    const OriginalObserver = globalThis.IntersectionObserver;
+    globalThis.IntersectionObserver = class {
+      constructor(callback: IntersectionObserverCallback) { notify = callback; }
+      observe = vi.fn();
+      disconnect = disconnect;
+    } as unknown as typeof IntersectionObserver;
+    try {
+      mockHookReturn();
+      const { unmount } = render(<ProgressiveImage src="/full.jpg" thumbSrc="/thumb.jpg" midSrc="/mid.jpg" alt="Lazy scan" loading="lazy" />);
+      expect(mockUseProgressiveImage).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
+      expect(screen.getByAltText('Lazy scan')).not.toHaveAttribute('src');
+      act(() => notify([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver));
+      expect(mockUseProgressiveImage).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: true }));
+      expect(screen.getByAltText('Lazy scan')).toHaveAttribute('src', '/full.jpg');
+      unmount();
+      expect(disconnect).toHaveBeenCalled();
+    } finally {
+      globalThis.IntersectionObserver = OriginalObserver;
+    }
+  });
+
   it('renders an <img> element with the correct src and alt', () => {
     mockHookReturn({ fullLoaded: true, currentSrc: '/images/full.jpg' });
 

--- a/frontend/src/hooks/useProgressiveImage.ts
+++ b/frontend/src/hooks/useProgressiveImage.ts
@@ -3,6 +3,7 @@ import { recordImageLoad } from '../utils/imagePerformance';
 import { imagePreloadService } from '../services/imagePreloadService';
 
 export interface ProgressiveImageOptions {
+  enabled?: boolean;
   thumbSrc: string;
   midSrc?: string;
   fullSrc: string;
@@ -93,6 +94,7 @@ export function useProgressiveImage(
     thumbSrc,
     midSrc,
     fullSrc,
+    enabled = true,
     idleUpgrade = false,
     deferFullUntilVisible = false,
     context = 'unknown',
@@ -113,6 +115,7 @@ export function useProgressiveImage(
   const dimsSetRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) return;
     const alreadyPreloaded = imagePreloadService.isPreloaded(fullSrc);
     const dims = alreadyPreloaded ? imagePreloadService.getDimensions(fullSrc) : null;
     setThumbLoaded(false);
@@ -182,7 +185,7 @@ export function useProgressiveImage(
       }
       imgsRef.current = [];
     };
-  }, [thumbSrc, midSrc, fullSrc, idleUpgrade, deferFullUntilVisible, context, fullDelay]);
+  }, [enabled, thumbSrc, midSrc, fullSrc, idleUpgrade, deferFullUntilVisible, context, fullDelay]);
 
   const currentSrc = fullLoaded ? fullSrc : midLoaded && midSrc ? midSrc : thumbLoaded ? thumbSrc : '';
 

--- a/frontend/src/pages/LetterDetailPage.tsx
+++ b/frontend/src/pages/LetterDetailPage.tsx
@@ -467,7 +467,7 @@ export default function LetterDetailPage() {
         {/* ── 3. Scan Image Carousel ──────────────────────── */}
         {carouselImages.length > 0 && (
           <figure className="letter-scan-figure">
-            <div className="scan-carousel" ref={carouselRef} data-swipe-ignore>
+            <div className="scan-carousel" ref={carouselRef} data-swipe-ignore data-image-scroll-root>
               {carouselImages.map((img, idx) => {
                 const isLetter = img.type === "letter";
                 const typeLabel = isLetter


### PR DESCRIPTION
Collection showcase slides and catalogue cards were fetching hidden image tiers immediately, bypassing lazy loading. Mount only the active showcase scan and wait until lazy progressive images are near the viewport before starting any tier or assigning a DOM image source.

Validation: 1,108 frontend tests and production build pass. Added visibility and 100-slide navigation regressions. A local mobile browser using the real public collection 009 data started about 37 image requests versus about 94 on the current production page; scrolling triggered additional images. This is a local request-count comparison, not a production latency claim; repeat after deployment.
