### PR TITLE
Reduce archive scrolling to one image request per card

### DIFF
--- a/frontend/src/components/LetterCard/LetterCard.tsx
+++ b/frontend/src/components/LetterCard/LetterCard.tsx
@@ -2,11 +2,10 @@ import { memo, useEffect, useRef, useState, type MouseEvent, type ReactNode, typ
 import "../ArchiveList/ArchiveList.css";
 import type { ArchiveSearchHighlightRange, LetterCardData } from "../../types/Letter";
 import { getImageUrl } from "../../api/client";
-import { ProgressiveImage } from "../common";
+import { PreviewImage } from "../common/PreviewImage";
 import { getMediaLabel } from "../../utils/letterPreview";
 import { imagePreloadService } from "../../services/imagePreloadService";
 import useIsTouchDevice from "../../hooks/useIsTouchDevice";
-import { getAppScrollRootForIO } from "../../utils/appScroll";
 
 interface LetterCardProps {
   card: LetterCardData;
@@ -146,7 +145,6 @@ function LetterCard({
   const searchPreview = card.searchPreview;
   const hasSearchPreview = Boolean(searchPreview?.excerpt && searchPreview.matchCount > 0);
   const [previewVisible, setPreviewVisible] = useState(false);
-  const [prioritizeImageLoad, setPrioritizeImageLoad] = useState(false);
   const previewTimerRef = useRef<number | null>(null);
   const touchReleaseTimerRef = useRef<number | null>(null);
   const hoverActiveRef = useRef(false);
@@ -170,26 +168,6 @@ function LetterCard({
     primaryChip,
     hook,
   ].filter((value): value is string => Boolean(value)).join(", ");
-
-  useEffect(() => {
-    const node = shellRef.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setPrioritizeImageLoad(true);
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (!entries.some((entry) => entry.isIntersecting)) return;
-        setPrioritizeImageLoad(true);
-        observer.disconnect();
-      },
-      { root: getAppScrollRootForIO(), rootMargin: "1200px 0px" },
-    );
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [card.id]);
 
   const clearPreviewTimer = () => {
     if (previewTimerRef.current !== null) {
@@ -347,18 +325,10 @@ function LetterCard({
         aria-label={ariaLabel || `${mediaLabel}: ${card.title || "Unknown item"}`}
       >
         {hasImage ? (
-          <ProgressiveImage
+          <PreviewImage
             className="letter-card-image"
             src={getImageUrl(card.imageUrl!, { width: 480 })}
-            thumbSrc={getImageUrl(card.imageUrl!, { width: 32 })}
-            midSrc={getImageUrl(card.imageUrl!, { width: 240 })}
             alt=""
-            loading={prioritizeImageLoad ? "eager" : "lazy"}
-            decoding="async"
-            fetchPriority={prioritizeImageLoad ? "high" : "low"}
-            context="archive-card"
-            idleUpgrade
-            deferFullUntilVisible={!prioritizeImageLoad}
           />
         ) : (
           <div className="letter-card-fallback" aria-hidden="true">

--- a/frontend/src/components/common/PreviewImage.css
+++ b/frontend/src/components/common/PreviewImage.css
@@ -1,0 +1,19 @@
+.preview-image {
+  overflow: hidden;
+}
+
+.preview-image__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.preview-image__error {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: rgba(255, 250, 242, 0.8);
+  font-size: 0.8rem;
+}

--- a/frontend/src/components/common/PreviewImage.tsx
+++ b/frontend/src/components/common/PreviewImage.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+import { getAppScrollRootForIO } from '../../utils/appScroll';
+import './PreviewImage.css';
+import { recordImageLoad } from '../../utils/imagePerformance';
+
+/** Small card previews need one display-sized image, not several competing tiers. */
+export function PreviewImage({ src, alt, className }: { src: string; alt: string; className?: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [nearViewport, setNearViewport] = useState(() => typeof IntersectionObserver === 'undefined');
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (nearViewport) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      setNearViewport(true);
+      observer.disconnect();
+    }, { root: containerRef.current?.closest('[data-image-scroll-root]') ?? getAppScrollRootForIO(), rootMargin: '1200px 0px' });
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [nearViewport]);
+
+  return (
+    <div ref={containerRef} className={`preview-image ${className ?? ''}`}>
+      <img
+        className="preview-image__image"
+        src={nearViewport ? src : undefined}
+        alt={alt}
+        loading="eager"
+        decoding="async"
+        draggable={false}
+        onLoad={() => {
+          const timing = performance.getEntriesByName(src, 'resource').at(-1) as PerformanceResourceTiming | undefined;
+          recordImageLoad({ url: src, context: 'archive-card', tier: 'full', durationMs: timing?.duration ?? 0,
+            cached: Boolean(timing && timing.transferSize === 0 && timing.decodedBodySize > 0) });
+        }}
+        onError={() => setFailedSrc(src)}
+        style={failedSrc === src ? { visibility: 'hidden' } : undefined}
+      />
+      {failedSrc === src && <span className="preview-image__error">Image unavailable</span>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/PreviewImage.test.tsx
+++ b/frontend/src/components/common/__tests__/PreviewImage.test.tsx
@@ -1,0 +1,45 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PreviewImage } from '../PreviewImage';
+
+const OriginalObserver = globalThis.IntersectionObserver;
+afterEach(() => { globalThis.IntersectionObserver = OriginalObserver; });
+
+describe('PreviewImage', () => {
+  it('starts one display-size image near the scrollport and leaves it available on return', () => {
+    let notify: IntersectionObserverCallback;
+    let options: IntersectionObserverInit | undefined;
+    const disconnect = vi.fn();
+    globalThis.IntersectionObserver = class {
+      constructor(callback: IntersectionObserverCallback, init: IntersectionObserverInit) { notify = callback; options = init; }
+      observe = vi.fn();
+      disconnect = disconnect;
+    } as unknown as typeof IntersectionObserver;
+    const { container, unmount } = render(<div data-image-scroll-root><PreviewImage src="/images/page?w=480" alt="Scan" /></div>);
+    const img = screen.getByAltText('Scan');
+    expect(img).not.toHaveAttribute('src');
+    expect(options).toMatchObject({ root: container.firstChild, rootMargin: '1200px 0px' });
+    act(() => notify([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver));
+    expect(img).toHaveAttribute('src', '/images/page?w=480');
+    expect(container.querySelectorAll('img')).toHaveLength(1);
+    expect(img).not.toHaveAttribute('fetchpriority', 'high');
+    act(() => notify([{ isIntersecting: false } as IntersectionObserverEntry], {} as IntersectionObserver));
+    expect(img).toHaveAttribute('src', '/images/page?w=480');
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('loads without IntersectionObserver and recovers when a failed source changes', () => {
+    globalThis.IntersectionObserver = undefined as unknown as typeof IntersectionObserver;
+    const { rerender } = render(<PreviewImage src="/missing" alt="Scan" />);
+    const img = screen.getByAltText('Scan');
+    expect(img).toHaveAttribute('src', '/missing');
+    fireEvent.error(img);
+    expect(screen.getByText('Image unavailable')).toBeVisible();
+    expect(img).not.toBeVisible();
+    rerender(<PreviewImage src="/replacement" alt="Scan" />);
+    expect(img).toHaveAttribute('src', '/replacement');
+    expect(img).toBeVisible();
+    expect(screen.queryByText('Image unavailable')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Archive scrolling currently starts 32, 240 and 480 pixel requests per card, using two visibility observers, detached image loaders and a final fade. Small previews now use one native 480 pixel image, preserving the existing 1200 pixel advance-loading margin, error fallback and load telemetry.

In two repeated controlled desktop scrolling trials against the production image API (4 Mbps, 80 ms added latency, 650 pixel scroll steps every 400 ms), image requests fell from 283 to 96 and transferred image bytes from about 3.28 MB to 2.47 MB. P95 visible full-quality waits fell from 3.05 seconds to 0.35 seconds; no images remained unresolved. Mobile requests fell from 265 to 90. These are controlled browser measurements, not real-user percentiles. Source image resolution and encoding are unchanged.

Validation: focused preview/card tests pass (7 tests); frontend production build and lint regression gate pass. Full CI is required before merge. The repeatable harness and full comparison report are being prepared as part of this image-loading investigation. Cloud configuration, cache publication policy and the separate handwriting checkout are untouched.
